### PR TITLE
Remove date requested from the request object

### DIFF
--- a/TokenAdministrationApi.Tests/V1/E2ETests/PostTokenIntegrationTests.cs
+++ b/TokenAdministrationApi.Tests/V1/E2ETests/PostTokenIntegrationTests.cs
@@ -30,7 +30,6 @@ namespace TokenAdministrationApi.Tests.V1.E2ETests
                 ApiName = _faker.Random.Int(0, 10),
                 HttpMethodType = "GET",
                 AuthorizedBy = _faker.Person.Email,
-                DateRequested = DateTime.Now,
                 Environment = _faker.Random.AlphaNumeric(5),
                 RequestedBy = _faker.Person.Email
             };
@@ -86,7 +85,6 @@ namespace TokenAdministrationApi.Tests.V1.E2ETests
                 ApiName = _faker.Random.Int(0, 10),
                 HttpMethodType = "GET",
                 AuthorizedBy = _faker.Person.Email,
-                DateRequested = DateTime.Now,
                 Environment = _faker.Random.AlphaNumeric(5),
                 RequestedBy = _faker.Person.Email
             };
@@ -108,7 +106,6 @@ namespace TokenAdministrationApi.Tests.V1.E2ETests
                 ApiName = _faker.Random.Int(0, 10),
                 HttpMethodType = "GET",
                 AuthorizedBy = _faker.Person.Email,
-                DateRequested = DateTime.Now,
                 Environment = _faker.Random.AlphaNumeric(5),
                 RequestedBy = _faker.Person.Email
             };
@@ -131,7 +128,6 @@ namespace TokenAdministrationApi.Tests.V1.E2ETests
                 ApiName = _faker.Random.Int(0, 10),
                 HttpMethodType = "TEST",
                 AuthorizedBy = _faker.Person.Email,
-                DateRequested = DateTime.Now,
                 Environment = _faker.Random.AlphaNumeric(5),
                 RequestedBy = _faker.Person.Email
             };

--- a/TokenAdministrationApi/V1/Boundary/Requests/TokenRequestObject.cs
+++ b/TokenAdministrationApi/V1/Boundary/Requests/TokenRequestObject.cs
@@ -51,11 +51,6 @@ namespace TokenAdministrationApi.V1.Boundary.Requests
         /// <example>
         /// 2020-05-15
         /// </example>
-        [Required]
-        public DateTime DateRequested { get; set; }
-        /// <example>
-        /// 2020-05-15
-        /// </example>
         [ExpiryDateValidationAttribute(ErrorMessage = "Token expiry date should be a future date")]
         public DateTime? ExpiresAt { get; set; }
     }


### PR DESCRIPTION
The field is unused and is instead set as the current time when a record is added to the database.