### PR TITLE
Swap terraform apply to plan to sync infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
           name: apply
           command: |
             cd ./terraform/<<parameters.environment>>/
-            terraform apply -auto-approve
+            terraform plan
   deploy-lambda:
     description: "Deploys API via Serverless"
     parameters:


### PR DESCRIPTION
Huge amount of drift in the terraform plan compared to the current state - see screenshot below
This is because infrastructure has been added/changed/removed outside of the pipeline (bad)
Replace apply with plan so that we can synchronise the plan with reality

![image](https://user-images.githubusercontent.com/8542878/223491707-9f3c70c2-302a-4bf5-8715-145a0f16a9af.png)
