### PR TITLE
Update instance generation

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -56,7 +56,7 @@ module "postgres_db_production" {
   environment_name = "production"
   vpc_id = data.aws_vpc.production_vpc.id
   db_engine = "postgres"
-  db_engine_version = "11.1"
+  db_engine_version = "11.16"
   db_identifier = "auth-token-generator-prod-db"
   db_instance_class = "db.t3.micro"
   db_name = "auth_token_generator_db"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -58,7 +58,7 @@ module "postgres_db_production" {
   db_engine = "postgres"
   db_engine_version = "11.1"
   db_identifier = "auth-token-generator-prod-db"
-  db_instance_class = "db.t2.micro"
+  db_instance_class = "db.t3.micro"
   db_name = "auth_token_generator_db"
   db_port  = 5100
   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -56,7 +56,7 @@ module "postgres_db_staging" {
   db_engine = "postgres"
   db_engine_version = "11.1"
   db_identifier = "auth-token-generator-staging-db"
-  db_instance_class = "db.t2.micro"
+  db_instance_class = "db.t3.micro"
   db_name = "auth_token_generator_db"
   db_port  = 5102
   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -54,7 +54,7 @@ module "postgres_db_staging" {
   environment_name = "staging"
   vpc_id = data.aws_vpc.staging_vpc.id
   db_engine = "postgres"
-  db_engine_version = "11.1"
+  db_engine_version = "11.16"
   db_identifier = "auth-token-generator-staging-db"
   db_instance_class = "db.t3.micro"
   db_name = "auth_token_generator_db"


### PR DESCRIPTION
- Terraform plan out of date
- The DB instance type (size + generation) was updated outside of the plan
- t2 has not been offered for a long time
- Also doesn't support new hackney standards such as encryption at rest

Reality:
![image](https://user-images.githubusercontent.com/8542878/223702857-995e956f-d921-4cb9-874f-a563f89056e5.png)

Error:
![image](https://user-images.githubusercontent.com/8542878/223702937-1d996261-78f4-4fda-9243-daa69c21c62e.png)
