### PR TITLE
Update ca authority work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ tmp/
 
 .fake
 .ionide
+terraform/production/.terraform/
+terraform/staging/.terraform/
+*.hcl

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -32,7 +32,7 @@ terraform {
 /*    POSTGRES SET UP    */
 data "aws_vpc" "production_vpc" {  
   tags = {    
-    Name = "vpc-production-apis-production"  
+    Name = "apis-prod"  
     }
 }
 data "aws_subnet_ids" "production" {  
@@ -56,7 +56,7 @@ module "postgres_db_production" {
   environment_name = "production"
   vpc_id = data.aws_vpc.production_vpc.id
   db_engine = "postgres"
-  db_engine_version = "11.16"
+  db_engine_version = "11.22"
   db_identifier = "auth-token-generator-prod-db"
   db_instance_class = "db.t3.micro"
   db_name = "auth_token_generator_db"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -54,7 +54,7 @@ module "postgres_db_staging" {
   environment_name = "staging"
   vpc_id = data.aws_vpc.staging_vpc.id
   db_engine = "postgres"
-  db_engine_version = "11.16"
+  db_engine_version = "11.22"
   db_identifier = "auth-token-generator-staging-db"
   db_instance_class = "db.t3.micro"
   db_name = "auth_token_generator_db"


### PR DESCRIPTION
## Why this change
When updating the database certificate authority on the project, it was discovered that the terraform state has drifted slightly.  This PR triggers the CA update but also syncs the state files with the current configuration on the cloud.