### PR TITLE
Move api keys config

### DIFF
--- a/TokenAdministrationApi/serverless.yml
+++ b/TokenAdministrationApi/serverless.yml
@@ -5,14 +5,13 @@ provider:
   vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
   region: eu-west-2
-  apiKeys:
-    - secureAccess:
+  apiGateway:
+    apiKeys:
       - api-key-${self:service}-${self:provider.stage}
-  usagePlan:
-    - secureAccess:
-        throttle:
-          burstLimit: 200
-          rateLimit: 100
+    usagePlan:
+      throttle:
+        burstLimit: 200
+        rateLimit: 100
 
 package:
   artifact: ./bin/release/net8.0/token-administration-api.zip


### PR DESCRIPTION
API keys in serverless config have been moved under apiGateway property. This updates the API key config to be inline with the current serverless version requirements. 

1. [Documentation](https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml)
2. [Sample configuration](https://github.com/LBHackney-IT/lbh-housing-api/blob/54c885623825c7d2aae7f85e6275057f14337e3f/HousingRegisterApi/serverless.yml#L14)