### PR TITLE
TS-2077 remove unnecessary policy from lambda execution role

### DIFF
--- a/TokenAdministrationApi/serverless.yml
+++ b/TokenAdministrationApi/serverless.yml
@@ -63,15 +63,6 @@ resources:
                           - Ref: 'AWS::Region'
                           - Ref: 'AWS::AccountId'
                           - 'log-group:/aws/lambda/*:*:*'
-                - Effect: "Allow"
-                  Action:
-                    - "s3:PutObject"
-                    - "s3:GetObject"
-                  Resource:
-                    Fn::Join:
-                      - ""
-                      - - "arn:aws:s3:::"
-                        - "Ref": "ServerlessDeploymentBucket"
           - PolicyName: lambdaInvocation
             PolicyDocument:
               Version: '2012-10-17'


### PR DESCRIPTION
When deploying to new environment with Serverless V4 the `"Ref": "ServerlessDeploymentBucket"` is no longer available which is causing the deployment to fail with _"The CloudFormation template is invalid: Template format error: Unresolved resource dependencies [ServerlessDeploymentBucket] in the Resources block of the template"_

The reference is used in the `lambdaExecutionRole` policy that gives the Lambda access to the Serverless deployment bucket. Because Serverless must be able to resolve all variables regardless whether they are actually used, conditions can't be used in this instance to achieve optional deployment of tbe resource. Rather than deploying the policy by some othher means, like with Terraform for example, I think it makes sense to remove the policy altogether since I think it's unnecessary. I have validated this with the Contracts API all the way to production and removing the policy makes no difference to the deployment process or the functionality of the Lambda. 

