### PR TITLE
Resolve a bunch of pipeline issues, rewrite pipeline to be better organised.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,19 +333,20 @@ workflows:
           requires: [ assume-role-production ]
 
   deploy-infrastructure:
-    - permit-development-terraform-release:
-        type: approval
-        filters:
-          branches:
-            only: development
-    - assume-role-development:
-        context: api-assume-role-development-context
-        requires: [ permit-development-terraform-release ]
-    # This job will be removed in the future PR
-    - fix-development-env-terraform-provider:
-          requires: [ assume-role-development ]
-    - terraform-init-and-apply-to-development:
-        requires: [ assume-role-development, fix-development-env-terraform-provider ]
+    jobs:
+      - permit-development-terraform-release:
+          type: approval
+          filters:
+            branches:
+              only: development
+      - assume-role-development:
+          context: api-assume-role-development-context
+          requires: [ permit-development-terraform-release ]
+      # This job will be removed in the future PR
+      - fix-development-env-terraform-provider:
+            requires: [ assume-role-development ]
+      - terraform-init-and-apply-to-development:
+          requires: [ assume-role-development, fix-development-env-terraform-provider ]
 
   development-deployment:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ workflows:
       - preview-terraform-production:
           requires: [ assume-role-production ]
 
-  check-and-deploy-development:
+  development-deployment:
     jobs:
       - check-code-formatting:
           filters:
@@ -316,31 +316,14 @@ workflows:
               only: development
       - assume-role-development:
           context: api-assume-role-development-context
-          requires:
-            - build-and-test
-          filters:
-            branches:
-              only: development
+          requires: [ build-and-test ]
       - terraform-init-and-apply-to-development:
-          requires:
-            - assume-role-development
-          filters:
-            branches:
-              only: development
+          requires: [ assume-role-development ]
       - migrate-database-development:
-          requires:
-            - terraform-init-and-apply-to-development
-            - assume-role-development
-          filters:
-            branches:
-              only: development
+          requires: [ terraform-init-and-apply-to-development ]
       - deploy-to-development:
-          requires:
-            - assume-role-development
-            - migrate-database-development
-          filters:
-            branches:
-              only: development
+          requires: [ migrate-database-development ]
+
   check-and-deploy-staging-and-production:
     jobs:
       - build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@3.0.0
   aws-cli: circleci/aws-cli@5.4.1
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_18.x | bash -
+            curl -sL https://deb.nodesource.com/setup_22.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
@@ -431,7 +431,6 @@ workflows:
           filters:
             branches:
               only: master
-  
   deploy-code-pre-production:
     jobs:
       - permit-pre-production-code-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,19 +334,40 @@ workflows:
 
   deploy-infrastructure:
     jobs:
-      - permit-development-terraform-release:
+      - deploy-development-infrastructure:
           type: approval
           filters:
             branches:
               only: development
       - assume-role-development:
           context: api-assume-role-development-context
-          requires: [ permit-development-terraform-release ]
+          requires: [ deploy-development-infrastructure ]
       # This job will be removed in the future PR
       - fix-development-env-terraform-provider:
             requires: [ assume-role-development ]
       - terraform-init-and-apply-to-development:
           requires: [ assume-role-development, fix-development-env-terraform-provider ]
+      - deploy-staging-infrastructure:
+          type: approval
+          filters:
+            branches:
+              only: master
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          requires: [ deploy-staging-infrastructure ]
+      - terraform-init-and-apply-to-staging:
+          requires: [ assume-role-staging ]
+      - deploy-production-infrastructure:
+          type: approval
+          filters:
+            branches:
+              only: master
+      - assume-role-production:
+          context: api-assume-role-production-context
+          requires: [ deploy-production-infrastructure ]
+      - terraform-init-and-apply-to-production:
+          requires: [ assume-role-production ]
+      
 
   development-deployment:
     jobs:
@@ -378,15 +399,8 @@ workflows:
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires: [ build-and-test ]
-      - preview-terraform-staging:
-          requires: [ assume-role-staging ]
-      - permit-staging-terraform-release:
-          type: approval
-          requires: [ preview-terraform-staging ]
-      - terraform-init-and-apply-to-staging:
-          requires: [ permit-staging-terraform-release ]
       - migrate-database-staging:
-          requires: [ terraform-init-and-apply-to-staging ]
+          requires: [ assume-role-staging ]
       - deploy-to-staging:
           context: [ "Serverless Framework" ]
           requires: [ migrate-database-staging ]
@@ -396,16 +410,9 @@ workflows:
       - assume-role-production:
           context: api-assume-role-production-context
           requires: [ start-production-release ]
-      - preview-terraform-production:
-          requires: [ assume-role-production ]
-      - permit-production-terraform-release:
-          type: approval
-          requires: [ preview-terraform-production ]
-      - terraform-init-and-apply-to-production:
-          requires: [ permit-production-terraform-release ]
-      # TODO: should be after the permit, and TODO: split TF release out
+      # TODO: should be after the permit
       - migrate-database-production:
-          requires: [ terraform-init-and-apply-to-production ]
+          requires: [ assume-role-production ]
       - permit-production-release:
           type: approval
           requires: [ migrate-database-production ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,10 +274,28 @@ jobs:
           stage: "pre-production"
 
 workflows:
+  feature:
+    jobs:
+      - check-code-formatting:
+          filters:
+            branches:
+              ignore: [ development, master ]
+      - build-and-test:
+          requires: check-code-formatting
+          filters:
+            branches:
+              ignore: [ development, master ]
+
   check-and-deploy-development:
     jobs:
-      - check-code-formatting
-      - build-and-test
+      - check-code-formatting:
+          filters:
+            branches:
+              only: development
+      - build-and-test:
+          filters:
+            branches:
+              only: development
       - assume-role-development:
           context: api-assume-role-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,34 @@ jobs:
     steps:
       - migrate-database:
           stage: "pre-production"
+  # This job will be removed later on. Adding it in for the sake of transparency
+  fix-development-env-terraform-provider:
+    executor: docker-terraform
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          name: Initialize Terraform
+          command: |
+            cd terraform/development/
+            terraform get -update=true
+            terraform init || true
+      - run:
+          name: List providers
+          command: |
+            cd terraform/development/
+            terraform providers || true
+      - run:
+          name: Replace legacy AWS provider with the new one
+          command: |
+            cd terraform/development/
+            terraform state replace-provider "registry.terraform.io/-/aws" "hashicorp/aws"
+      - run:
+          name: Confirm the change in providers
+          command: |
+            cd terraform/development/
+            terraform init || true
+            terraform providers
 
 workflows:
   feature:
@@ -317,8 +345,10 @@ workflows:
       - assume-role-development:
           context: api-assume-role-development-context
           requires: [ build-and-test ]
-      - terraform-init-and-apply-to-development:
+      - fix-development-env-terraform-provider:
           requires: [ assume-role-development ]
+      - terraform-init-and-apply-to-development:
+          requires: [ assume-role-development, fix-development-env-terraform-provider ]
       - migrate-database-development:
           requires: [ terraform-init-and-apply-to-development ]
       - deploy-to-development:
@@ -358,6 +388,7 @@ workflows:
           requires: [ preview-terraform-production ]
       - terraform-init-and-apply-to-production:
           requires: [ permit-production-terraform-release ]
+      # TODO: should be after the permit, and TODO: split TF release out
       - migrate-database-production:
           requires: [ terraform-init-and-apply-to-production ]
       - permit-production-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,10 +345,17 @@ workflows:
       - deploy-to-staging:
           context: [ "Serverless Framework" ]
           requires: [ migrate-database-staging ]
+      - start-production-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+          filters:
+            branches:
+              only: master
       - assume-role-production:
           context: api-assume-role-production-context
           requires:
-              - deploy-to-staging
+              - start-production-release
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,12 +279,31 @@ workflows:
       - check-code-formatting:
           filters:
             branches:
-              ignore: [development, master]
+              ignore: [ development, master ]
       - build-and-test:
-          requires: [check-code-formatting]
+          requires: [ check-code-formatting ]
+      - assume-role-development:
+          context: api-assume-role-development-context
           filters:
             branches:
-              ignore: [development, master]
+              ignore: [ development, master ]
+      - preview-terraform-development:
+          requires: [ assume-role-development ]
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          filters:
+            branches:
+              ignore: [ development, master ]
+      - preview-terraform-staging:
+          requires: [ assume-role-staging ]
+      - assume-role-production:
+          context: api-assume-role-production-context
+          requires: [ deploy-to-staging ]
+          filters:
+            branches:
+              ignore: [ development, master ]
+      - preview-terraform-production:
+          requires: [ assume-role-production ]
 
   check-and-deploy-development:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   docker-python:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.14
   docker-terraform:
     docker:
       - image: "hashicorp/terraform:light"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,16 @@ commands:
       - *attach_workspace
       - checkout
       - run:
+          name: Initialize Terraform
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform get -update=true
             terraform init
+      - run:
+          name: Preview Terraform changes
+          command: |
+            cd ./terraform/<<parameters.environment>>/
             terraform plan
-          name: get, init, and plan
   terraform-init-then-apply:
     description: "Initializes and applies terraform configuration"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,12 +279,12 @@ workflows:
       - check-code-formatting:
           filters:
             branches:
-              ignore: [ development, master ]
+              ignore: [development, master]
       - build-and-test:
-          requires: check-code-formatting
+          requires: [check-code-formatting]
           filters:
             branches:
-              ignore: [ development, master ]
+              ignore: [development, master]
 
   check-and-deploy-development:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,9 +396,12 @@ workflows:
           filters:
             branches:
               only: master
+      - start-staging-deployment:
+          type: approval
+          requires: [ build-and-test ]
       - assume-role-staging:
           context: api-assume-role-staging-context
-          requires: [ build-and-test ]
+          requires: [ start-staging-deployment ]
       - migrate-database-staging:
           requires: [ assume-role-staging ]
       - deploy-to-staging:
@@ -410,15 +413,11 @@ workflows:
       - assume-role-production:
           context: api-assume-role-production-context
           requires: [ start-production-release ]
-      # TODO: should be after the permit
       - migrate-database-production:
           requires: [ assume-role-production ]
-      - permit-production-release:
-          type: approval
-          requires: [ migrate-database-production ]
       - deploy-to-production:
           context: [ "Serverless Framework" ]
-          requires: [ permit-production-release ]
+          requires: [ migrate-database-production ]
 
   deploy-terraform-pre-production:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,6 +332,21 @@ workflows:
       - preview-terraform-production:
           requires: [ assume-role-production ]
 
+  deploy-infrastructure:
+    - permit-development-terraform-release:
+        type: approval
+        filters:
+          branches:
+            only: development
+    - assume-role-development:
+        context: api-assume-role-development-context
+        requires: [ permit-development-terraform-release ]
+    # This job will be removed in the future PR
+    - fix-development-env-terraform-provider:
+          requires: [ assume-role-development ]
+    - terraform-init-and-apply-to-development:
+        requires: [ assume-role-development, fix-development-env-terraform-provider ]
+
   development-deployment:
     jobs:
       - check-code-formatting:
@@ -342,15 +357,14 @@ workflows:
           filters:
             branches:
               only: development
+      - start-development-deployment:
+          type: approval
+          requires: [ build-and-test ]
       - assume-role-development:
           context: api-assume-role-development-context
-          requires: [ build-and-test ]
-      - fix-development-env-terraform-provider:
-          requires: [ assume-role-development ]
-      - terraform-init-and-apply-to-development:
-          requires: [ assume-role-development, fix-development-env-terraform-provider ]
+          requires: [ start-development-deployment ]
       - migrate-database-development:
-          requires: [ terraform-init-and-apply-to-development ]
+          requires: [ assume-role-development ]
       - deploy-to-development:
           requires: [ migrate-database-development ]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,6 @@ workflows:
           requires: [ assume-role-staging ]
       - assume-role-production:
           context: api-assume-role-production-context
-          requires: [ deploy-to-staging ]
           filters:
             branches:
               ignore: [ development, master ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
+  aws-cli: circleci/aws-cli@5.4.1
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,21 +327,21 @@ workflows:
   check-and-deploy-staging-and-production:
     jobs:
       - build-and-test:
-        filters:
-          branches:
-            only: master
+          filters:
+            branches:
+              only: master
       - assume-role-staging:
-         context: api-assume-role-staging-context
-         requires: [ build-and-test ]
+          context: api-assume-role-staging-context
+          requires: [ build-and-test ]
       - preview-terraform-staging:
           requires: [ assume-role-staging ]
       - permit-staging-terraform-release:
           type: approval
           requires: [ preview-terraform-staging ]
       - terraform-init-and-apply-to-staging:
-         requires: [ permit-staging-terraform-release ]
+          requires: [ permit-staging-terraform-release ]
       - migrate-database-staging:
-         requires: [ terraform-init-and-apply-to-staging ]
+          requires: [ terraform-init-and-apply-to-staging ]
       - deploy-to-staging:
           context: [ "Serverless Framework" ]
           requires: [ migrate-database-staging ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,46 +332,19 @@ workflows:
             only: master
       - assume-role-staging:
          context: api-assume-role-staging-context
-         requires:
-             - build-and-test
-         filters:
-           branches:
-             only: master
+         requires: [ build-and-test ]
       - preview-terraform-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: master
+          requires: [ assume-role-staging ]
       - permit-staging-terraform-release:
           type: approval
-          requires:
-            - preview-terraform-staging
-          filters:
-            branches:
-              only: master
+          requires: [ preview-terraform-staging ]
       - terraform-init-and-apply-to-staging:
-         requires:
-           - permit-staging-terraform-release
-         filters:
-           branches:
-             only: master
+         requires: [ permit-staging-terraform-release ]
       - migrate-database-staging:
-         requires:
-           - terraform-init-and-apply-to-staging
-           - assume-role-staging
-         filters:
-            branches:
-              only: master
+         requires: [ terraform-init-and-apply-to-staging ]
       - deploy-to-staging:
-          context:
-            - "Serverless Framework"
-          requires:
-            - assume-role-staging
-            - migrate-database-staging
-          filters:
-            branches:
-              only: master
+          context: [ "Serverless Framework" ]
+          requires: [ migrate-database-staging ]
       - assume-role-production:
           context: api-assume-role-production-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,58 +347,25 @@ workflows:
           requires: [ migrate-database-staging ]
       - start-production-release:
           type: approval
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: master
+          requires: [ deploy-to-staging ]
       - assume-role-production:
           context: api-assume-role-production-context
-          requires:
-              - start-production-release
-          filters:
-            branches:
-              only: master
+          requires: [ start-production-release ]
       - preview-terraform-production:
-          requires:
-            - assume-role-production
-          filters:
-            branches:
-              only: master
+          requires: [ assume-role-production ]
       - permit-production-terraform-release:
           type: approval
-          requires:
-            - preview-terraform-production
+          requires: [ preview-terraform-production ]
       - terraform-init-and-apply-to-production:
-          requires:
-            - permit-production-terraform-release
-          filters:
-            branches:
-              only: master
+          requires: [ permit-production-terraform-release ]
       - migrate-database-production:
-          requires:
-            - terraform-init-and-apply-to-production
-            - assume-role-production
-          filters:
-            branches:
-              only: master
+          requires: [ terraform-init-and-apply-to-production ]
       - permit-production-release:
           type: approval
-          requires:
-            - migrate-database-production
-          filters:
-            branches:
-              only: master
+          requires: [ migrate-database-production ]
       - deploy-to-production:
-          context:
-            - "Serverless Framework"
-          requires:
-            - permit-production-release
-            - assume-role-production
-            - migrate-database-production
-          filters:
-            branches:
-              only: master
+          context: [ "Serverless Framework" ]
+          requires: [ permit-production-release ]
 
   deploy-terraform-pre-production:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,7 +324,7 @@ workflows:
       - deploy-to-development:
           requires: [ migrate-database-development ]
 
-  check-and-deploy-staging-and-production:
+  staging-and-production-deployment:
     jobs:
       - build-and-test:
           filters:

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -17,6 +17,7 @@ terraform {
 
   required_providers {
     aws = {
+      source  = "hashicorp/aws"
       version = "~> 2.0"
     }
   }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -1,6 +1,6 @@
-# INSTRUCTIONS: 
-# 1) ENSURE YOU POPULATE THE LOCALS 
-# 2) ENSURE YOU REPLACE ALL INPUT PARAMETERS, THAT CURRENTLY STATE 'ENTER VALUE', WITH VALID VALUES 
+# INSTRUCTIONS:
+# 1) ENSURE YOU POPULATE THE LOCALS
+# 2) ENSURE YOU REPLACE ALL INPUT PARAMETERS, THAT CURRENTLY STATE 'ENTER VALUE', WITH VALID VALUES
 # 3) YOUR CODE WOULD NOT COMPILE IF STEP NUMBER 2 IS NOT PERFORMED!
 # 4) ENSURE YOU CREATE A BUCKET FOR YOUR STATE FILE AND YOU ADD THE NAME BELOW - MAINTAINING THE STATE OF THE INFRASTRUCTURE YOU CREATE IS ESSENTIAL - FOR APIS, THE BUCKETS ALREADY EXIST
 # 5) THE VALUES OF THE COMMON COMPONENTS THAT YOU WILL NEED ARE PROVIDED IN THE COMMENTS
@@ -25,22 +25,22 @@ terraform {
     bucket  = "terraform-state-development-apis"
     encrypt = true
     region  = "eu-west-2"
-    key     = "services/auth-token-generator-api/state" 
+    key     = "services/auth-token-generator-api/state"
   }
 }
 
 /*    POSTGRES SET UP    */
-data "aws_vpc" "development_vpc" {  
-  tags = {    
-    Name = "apis-dev"  
+data "aws_vpc" "development_vpc" {
+  tags = {
+    Name = "apis-dev"
   }
 }
 
-data "aws_subnet_ids" "development_private_subnets" {  
-  vpc_id = data.aws_vpc.development_vpc.id  
-  filter {    
-    name   = "tag:Type"    
-    values = ["private"]  
+data "aws_subnet_ids" "development_private_subnets" {
+  vpc_id = data.aws_vpc.development_vpc.id
+  filter {
+    name   = "tag:Type"
+    values = ["private"]
   }
 }
 

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -7,9 +7,23 @@
 # 6) IF ADDITIONAL RESOURCES ARE REQUIRED BY YOUR API, ADD THEM TO THIS FILE
 # 7) ENSURE THIS FILE IS PLACED WITHIN A 'terraform' FOLDER LOCATED AT THE ROOT PROJECT DIRECTORY
 
+terraform {
+  backend "s3" {
+    bucket  = "terraform-state-development-apis"
+    encrypt = true
+    region  = "eu-west-2"
+    key     = "services/auth-token-generator-api/state"
+  }
+
+  required_providers {
+    aws = {
+      version = "~> 2.0"
+    }
+  }
+}
+
 provider "aws" {
   region  = "eu-west-2"
-  version = "~> 2.0"
 }
 
 data "aws_caller_identity" "current" {}
@@ -18,15 +32,6 @@ data "aws_region" "current" {}
 locals {
   application_name = "auth token generator api"
   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
-
-terraform {
-  backend "s3" {
-    bucket  = "terraform-state-development-apis"
-    encrypt = true
-    region  = "eu-west-2"
-    key     = "services/auth-token-generator-api/state"
-  }
 }
 
 /*    POSTGRES SET UP    */

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -52,23 +52,23 @@ data "aws_ssm_parameter" "auth_token_generator_postgres_username" {
   name = "/api-auth-token-generator/development/postgres-username"
 }
 
-module "postgres_db_development" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-  environment_name = "development"
-  vpc_id = data.aws_vpc.development_vpc.id
-  db_engine = "postgres"
-  db_engine_version = "11.1"
-  db_identifier = "auth-token-generator-dev-db"
-  db_instance_class = "db.t2.micro"
-  db_name = "auth_token_generator_db"
-  db_port  = 5101
-  db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
-  db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
-  subnet_ids = data.aws_subnet_ids.development_private_subnets.ids
-  db_allocated_storage = 20
-  maintenance_window ="sun:10:00-sun:10:30"
-  storage_encrypted = false
-  multi_az = false //only true if production deployment
-  publicly_accessible = false
-  project_name = "platform apis"
-}
+# module "postgres_db_development" {
+#   source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
+#   environment_name = "development"
+#   vpc_id = data.aws_vpc.development_vpc.id
+#   db_engine = "postgres"
+#   db_engine_version = "11.1"
+#   db_identifier = "auth-token-generator-dev-db"
+#   db_instance_class = "db.t2.micro"
+#   db_name = "auth_token_generator_db"
+#   db_port  = 5101
+#   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
+#   db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
+#   subnet_ids = data.aws_subnet_ids.development_private_subnets.ids
+#   db_allocated_storage = 20
+#   maintenance_window ="sun:10:00-sun:10:30"
+#   storage_encrypted = false
+#   multi_az = false //only true if production deployment
+#   publicly_accessible = false
+#   project_name = "platform apis"
+# }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -11,11 +11,13 @@ provider "aws" {
   region  = "eu-west-2"
   version = "~> 2.0"
 }
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
+
 locals {
   application_name = "auth token generator api"
-   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 terraform {
@@ -30,24 +32,25 @@ terraform {
 /*    POSTGRES SET UP    */
 data "aws_vpc" "development_vpc" {  
   tags = {    
-    Name = "vpc-development-apis-development"  
-    }
+    Name = "apis-dev"  
+  }
 }
+
 data "aws_subnet_ids" "development_private_subnets" {  
   vpc_id = data.aws_vpc.development_vpc.id  
   filter {    
     name   = "tag:Type"    
     values = ["private"]  
-    }
+  }
 }
 
- data "aws_ssm_parameter" "auth_token_generator_postgres_password" {
-   name = "/api-auth-token-generator/development/postgres-password"
- }
+data "aws_ssm_parameter" "auth_token_generator_postgres_password" {
+  name = "/api-auth-token-generator/development/postgres-password"
+}
 
- data "aws_ssm_parameter" "auth_token_generator_postgres_username" {
-   name = "/api-auth-token-generator/development/postgres-username"
- }
+data "aws_ssm_parameter" "auth_token_generator_postgres_username" {
+  name = "/api-auth-token-generator/development/postgres-username"
+}
 
 module "postgres_db_development" {
   source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -17,7 +17,7 @@ data "aws_region" "current" {}
 
 locals {
   application_name = "auth token generator api"
-   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 terraform {
@@ -33,23 +33,24 @@ terraform {
 data "aws_vpc" "production_vpc" {
   tags = {
     Name = "apis-prod"
-    }
+  }
 }
+
 data "aws_subnet_ids" "production" {
   vpc_id = data.aws_vpc.production_vpc.id
   filter {
     name   = "tag:Type"
     values = ["private"]
-    }
+  }
 }
 
- data "aws_ssm_parameter" "auth_token_generator_postgres_password" {
-   name = "/api-auth-token-generator/production/postgres-password"
- }
+data "aws_ssm_parameter" "auth_token_generator_postgres_password" {
+  name = "/api-auth-token-generator/production/postgres-password"
+}
 
- data "aws_ssm_parameter" "auth_token_generator_postgres_username" {
-   name = "/api-auth-token-generator/production/postgres-username"
- }
+data "aws_ssm_parameter" "auth_token_generator_postgres_username" {
+  name = "/api-auth-token-generator/production/postgres-username"
+}
 
 module "postgres_db_production" {
   source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -35,6 +35,7 @@ data "aws_vpc" "staging_vpc" {
     Name = "apis-stg"
   }
 }
+
 data "aws_subnet_ids" "staging" {
   vpc_id = data.aws_vpc.staging_vpc.id
   filter {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -11,11 +11,13 @@ provider "aws" {
   region  = "eu-west-2"
   version = "~> 2.0"
 }
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
+
 locals {
   application_name = "auth token generator api"
-   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 terraform {
@@ -31,23 +33,23 @@ terraform {
 data "aws_vpc" "staging_vpc" {
   tags = {
     Name = "apis-stg"
-    }
+  }
 }
 data "aws_subnet_ids" "staging" {
   vpc_id = data.aws_vpc.staging_vpc.id
   filter {
     name   = "tag:Type"
     values = ["private"]
-    }
+  }
 }
 
- data "aws_ssm_parameter" "auth_token_generator_postgres_password" {
-   name = "/api-auth-token-generator/staging/postgres-password"
- }
+data "aws_ssm_parameter" "auth_token_generator_postgres_password" {
+  name = "/api-auth-token-generator/staging/postgres-password"
+}
 
- data "aws_ssm_parameter" "auth_token_generator_postgres_username" {
-   name = "/api-auth-token-generator/staging/postgres-username"
- }
+data "aws_ssm_parameter" "auth_token_generator_postgres_username" {
+  name = "/api-auth-token-generator/staging/postgres-username"
+}
 
 module "postgres_db_staging" {
   source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"


### PR DESCRIPTION
# What:
 - Update pipeline's node from EOL `v18` to `v22` _(which is currently in maintenance until 2027)_.
 - Bump AWS CLI from `v0.1.9` to `v5.4.1`.
 - Replace the deprecated CirlceCI's convenience python image with the recent version of replacement cimg image.
 - Split the TF init and plan outputs into separate CCI steps.
 - Created the `feature` branch workflow.
 - Reduce the pipeline's config line count by removing redundant branch filters and inlining the 1 item lists.
 - Attempt to resolve the `terraform init` error of needing to switch to a new `aws` provider.
 - Split off the infrastructure deployment pipeline steps into a separate CCI workflow.

# Why:
 - Update dependencies to speed up the pipeline _(main culprit was the deprecated convenience image, though with the EOL node is likely to receive the deprecation warning 80sec timeout some time in the future)_.
 - Split the TF preview into 2 steps to prevent concatenation of outputs. This will reduce the amount of text we need to sift through to merely look at what operation TF plans to perform.
 - Added the `feature` workflow to be able to get quick feedback on TF drift and changes.
 - Simplified pipeline's config to make it easier to navigate and follow. There was too much repeated information there, and too many lines used to represent the most basic of information such as what step the current step depends on.
 - Renamed the CCI workflows to make it easy to see what they do.
 - Added a CCI job to the `development` workflow to fix the provider issue for the sake of transparency that this was done as well as for reference how it can be fixed.
 - Split the infrastructure steps into another workflow because infrastructure typically gets modified and released separately. As such, it's best not to slow down the infrastructure release process by having to redeploy the API application needlessly.

# Notes:
 - This PR is one of a couple PRs for the Jira ticket: [SSI-703](https://hackney.atlassian.net/browse/SSI-703), which is about setting up the PostgreSQL database within the development environment so we could test the future authorizer changes we're going to perform.
 - The terraform provider error:
   ```
    Error: Invalid legacy provider address
   │ 
   │ This configuration or its associated state refers to the unqualified provider "aws".
   │ 
   │ You must complete the Terraform 0.13 upgrade process before upgrading to later versions.
   ```
 - The failing development preview step should get fixed after this PR is merged and the newly added `development` workflow's step is run.
 - **Edit:** This PR has left out the auto-approve - it's added within this PR #34 .

[SSI-703]: https://hackney.atlassian.net/browse/SSI-703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ