### PR TITLE
Auto-approve the TF provider switch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ jobs:
           name: Replace legacy AWS provider with the new one
           command: |
             cd terraform/development/
-            terraform state replace-provider "registry.terraform.io/-/aws" "hashicorp/aws"
+            terraform state replace-provider -auto-approve "registry.terraform.io/-/aws" "hashicorp/aws"
       - run:
           name: Confirm the change in providers
           command: |


### PR DESCRIPTION
# What:
 - Added missing auto-approve flag.

# Why:
 - Without the auto-approve without which the pipeline halts as it expects user to press y/n.

# Notes:
  - A continuation of the PR #33 .
  - The pipeline is failing on the development TF preview because the step, which PR attempts to fix failed to run to resolve that issue.