### PR TITLE
Add Shared Services Github team as codeowners for this repository.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file specifies owners for pull request approval
 # See https://help.github.com/articles/about-code-owners/
 
-* @LBHackney-IT/housing-products @shared-services
+* @LBHackney-IT/housing-products @LBHackney-IT/shared-services

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file specifies owners for pull request approval
 # See https://help.github.com/articles/about-code-owners/
 
-* @LBHackney-IT/housing-products
+* @LBHackney-IT/housing-products @shared-services


### PR DESCRIPTION
# What:
 - Added "Shared Services" Github team as CODEOWNERs of this repository.

# Why:
 - So that we have Pull Request approval powers.
 - This repository is technically a shared service.