### PR TITLE
Clean up the Terraform legacy provider switch fix.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,34 +272,6 @@ jobs:
     steps:
       - migrate-database:
           stage: "pre-production"
-  # This job will be removed later on. Adding it in for the sake of transparency
-  fix-development-env-terraform-provider:
-    executor: docker-terraform
-    steps:
-      - *attach_workspace
-      - checkout
-      - run:
-          name: Initialize Terraform
-          command: |
-            cd terraform/development/
-            terraform get -update=true
-            terraform init || true
-      - run:
-          name: List providers
-          command: |
-            cd terraform/development/
-            terraform providers || true
-      - run:
-          name: Replace legacy AWS provider with the new one
-          command: |
-            cd terraform/development/
-            terraform state replace-provider -auto-approve "registry.terraform.io/-/aws" "hashicorp/aws"
-      - run:
-          name: Confirm the change in providers
-          command: |
-            cd terraform/development/
-            terraform init || true
-            terraform providers
 
 workflows:
   feature:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,11 +342,8 @@ workflows:
       - assume-role-development:
           context: api-assume-role-development-context
           requires: [ deploy-development-infrastructure ]
-      # This job will be removed in the future PR
-      - fix-development-env-terraform-provider:
-            requires: [ assume-role-development ]
       - terraform-init-and-apply-to-development:
-          requires: [ assume-role-development, fix-development-env-terraform-provider ]
+          requires: [ assume-role-development ]
       - deploy-staging-infrastructure:
           type: approval
           filters:


### PR DESCRIPTION
# What:
 - Remove the Terraform's outdated provider fix from the pipeline.

# Why:
 - These steps have successfully executed after the merging in of PRs #33 and #34 , and don't need to be run for the 2nd time.