### PR TITLE
Bring back `development` environment's token database.

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -63,7 +63,7 @@ module "postgres_db_development" {
   environment_name = "development"
   vpc_id = data.aws_vpc.development_vpc.id
   db_engine = "postgres"
-  db_engine_version = "11.1"
+  db_engine_version = "16.4"
   db_identifier = "auth-token-generator-dev-db"
   db_instance_class = "db.t2.micro"
   db_name = "auth_token_generator_db"

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -58,23 +58,23 @@ data "aws_ssm_parameter" "auth_token_generator_postgres_username" {
   name = "/api-auth-token-generator/development/postgres-username"
 }
 
-# module "postgres_db_development" {
-#   source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-#   environment_name = "development"
-#   vpc_id = data.aws_vpc.development_vpc.id
-#   db_engine = "postgres"
-#   db_engine_version = "11.1"
-#   db_identifier = "auth-token-generator-dev-db"
-#   db_instance_class = "db.t2.micro"
-#   db_name = "auth_token_generator_db"
-#   db_port  = 5101
-#   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
-#   db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
-#   subnet_ids = data.aws_subnet_ids.development_private_subnets.ids
-#   db_allocated_storage = 20
-#   maintenance_window ="sun:10:00-sun:10:30"
-#   storage_encrypted = false
-#   multi_az = false //only true if production deployment
-#   publicly_accessible = false
-#   project_name = "platform apis"
-# }
+module "postgres_db_development" {
+  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
+  environment_name = "development"
+  vpc_id = data.aws_vpc.development_vpc.id
+  db_engine = "postgres"
+  db_engine_version = "11.1"
+  db_identifier = "auth-token-generator-dev-db"
+  db_instance_class = "db.t2.micro"
+  db_name = "auth_token_generator_db"
+  db_port  = 5101
+  db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
+  db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
+  subnet_ids = data.aws_subnet_ids.development_private_subnets.ids
+  db_allocated_storage = 20
+  maintenance_window ="sun:10:00-sun:10:30"
+  storage_encrypted = false
+  multi_az = false //only true if production deployment
+  publicly_accessible = false
+  project_name = "platform apis"
+}

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -42,7 +42,7 @@ data "aws_vpc" "development_vpc" {
   }
 }
 
-data "aws_subnet_ids" "development_private_subnets" {
+data "aws_subnet_ids" "development" {
   vpc_id = data.aws_vpc.development_vpc.id
   filter {
     name   = "tag:Type"
@@ -66,7 +66,7 @@ module "postgres_db_development" {
   db_identifier = "auth-token-generator-dev-db"
 
   vpc_id = data.aws_vpc.development_vpc.id
-  subnet_ids = data.aws_subnet_ids.development_private_subnets.ids
+  subnet_ids = data.aws_subnet_ids.development.ids
   multi_az = false
   publicly_accessible = false
 

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -77,4 +77,5 @@ module "postgres_db_development" {
   multi_az = false //only true if production deployment
   publicly_accessible = false
   project_name = "platform apis"
+  copy_tags_to_snapshot = true
 }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -70,7 +70,7 @@ module "postgres_db_development" {
   multi_az = false
   publicly_accessible = false
 
-  db_instance_class = "db.t2.micro"
+  db_instance_class = "db.t3.micro"
   db_allocated_storage = 20
   storage_encrypted = false
 

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -78,4 +78,8 @@ module "postgres_db_development" {
   publicly_accessible = false
   project_name = "platform apis"
   copy_tags_to_snapshot = true
+
+  additional_tags = {
+    BackupPolicy = "Dev"
+  }
 }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -60,24 +60,29 @@ data "aws_ssm_parameter" "auth_token_generator_postgres_username" {
 
 module "postgres_db_development" {
   source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
+
   environment_name = "development"
+  project_name = "platform apis"
+  db_name = "auth_token_generator_db"
+  db_identifier = "auth-token-generator-dev-db"
+
   vpc_id = data.aws_vpc.development_vpc.id
+  subnet_ids = data.aws_subnet_ids.development_private_subnets.ids
+  multi_az = false
+  publicly_accessible = false
+
+  db_instance_class = "db.t2.micro"
+  db_allocated_storage = 20
+  storage_encrypted = false
+
   db_engine = "postgres"
   db_engine_version = "16.4"
-  db_identifier = "auth-token-generator-dev-db"
-  db_instance_class = "db.t2.micro"
-  db_name = "auth_token_generator_db"
-  db_port  = 5101
   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
   db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
-  subnet_ids = data.aws_subnet_ids.development_private_subnets.ids
-  db_allocated_storage = 20
-  maintenance_window ="sun:10:00-sun:10:30"
-  storage_encrypted = false
-  multi_az = false //only true if production deployment
-  publicly_accessible = false
-  project_name = "platform apis"
+  db_port  = 5101
+
   copy_tags_to_snapshot = true
+  maintenance_window ="sun:10:00-sun:10:30"
 
   additional_tags = {
     BackupPolicy = "Dev"

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -63,7 +63,6 @@ module "postgres_db_development" {
 
   environment_name = "development"
   project_name = "platform apis"
-  db_name = "auth_token_generator_db"
   db_identifier = "auth-token-generator-dev-db"
 
   vpc_id = data.aws_vpc.development_vpc.id
@@ -79,6 +78,7 @@ module "postgres_db_development" {
   db_engine_version = "16.4"
   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
   db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
+  db_name = "auth_token_generator_db"
   db_port  = 5101
 
   copy_tags_to_snapshot = true


### PR DESCRIPTION
# What:
 - Bring back the `development` environment's token PostgreSQL database.
 - Update PostgreSQL database engine version to a more recent one.
 - Make tags be preserved during the making of the snapshot.
 - Make backups process be aware that this is a development database.

# Why:
 - Bring back the development database so that we could trial and error solutions for our current authorizer work without needing to deploy the changes to the `master` branch and get them released to `staging` at a minimum.
 - Bump engine to match the `staging` and `production` environments _(so we can do predictable tests)_.
 - Preserve tags on snapshot so that the database restoration is quicker.
 - Add backup policy tag to make the backups process aware that the snapshots of this database don't need to be retained as long as the production ones.

# Notes:
 - I've confirmed that the SSM Parameter Store keys used by the Terraform: `/api-auth-token-generator/development/postgres-password`, `/api-auth-token-generator/development/postgres-username` exist, and have appropriate values specified.
 - I've confirmed that the connection string construction variables used by the dotnet applications have the correct Parameter Store values configured under its keys that match what this database will have. Even the port number, despite being different to `staging` and `production` environments is correctly specified within this key: `/api-auth-token-generator/development/postgres-port`.
 - TODO: After merging this PR and deploying the infrastructure, set the `/api-auth-token-generator/development/postgres-hostname` variable value. **Edit:** Done by PR #41 .