### PR TITLE
Bump PostgreSQL engine versions across all environments to match the cloud environment.

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -75,7 +75,7 @@ module "postgres_db_development" {
   storage_encrypted = false
 
   db_engine = "postgres"
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
   db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
   db_name = "auth_token_generator_db"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -69,7 +69,7 @@ module "postgres_db_production" {
   storage_encrypted = false
 
   db_engine = "postgres"
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
   db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
   db_name = "auth_token_generator_db"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -54,26 +54,32 @@ data "aws_ssm_parameter" "auth_token_generator_postgres_username" {
 
 module "postgres_db_production" {
   source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
+
   environment_name = "production"
-  vpc_id = data.aws_vpc.production_vpc.id
-  db_engine = "postgres"
-  db_engine_version = "16.4"
-  db_allow_major_version_upgrade = true
+  project_name = "platform apis"
   db_identifier = "auth-token-generator-prod-db"
-  db_instance_class = "db.t3.micro"
-  db_name = "auth_token_generator_db"
-  db_port  = 5100
-  db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
-  db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
+
+  vpc_id = data.aws_vpc.production_vpc.id
   subnet_ids = data.aws_subnet_ids.production.ids
-  db_allocated_storage = 20
-  maintenance_window ="sun:10:00-sun:10:30"
-  storage_encrypted = false
   multi_az = true
   publicly_accessible = false
-  project_name = "platform apis"
+
+  db_instance_class = "db.t3.micro"
+  db_allocated_storage = 20
+  storage_encrypted = false
+
+  db_engine = "postgres"
+  db_engine_version = "16.4"
+  db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
+  db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
+  db_name = "auth_token_generator_db"
+  db_port  = 5100
+
   deletion_protection = true
   copy_tags_to_snapshot = true
+  db_allow_major_version_upgrade = true
+  maintenance_window ="sun:10:00-sun:10:30"
+
   additional_tags = {
     BackupPolicy = "Prod"
   }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -54,24 +54,30 @@ data "aws_ssm_parameter" "auth_token_generator_postgres_username" {
 
 module "postgres_db_staging" {
   source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
+
   environment_name = "staging"
+  project_name = "platform apis"
+  db_identifier = "auth-token-generator-staging-db"
+
   vpc_id = data.aws_vpc.staging_vpc.id
+  subnet_ids = data.aws_subnet_ids.staging.ids
+  multi_az = false
+  publicly_accessible = false
+
+  db_instance_class = "db.t3.micro"
+  db_allocated_storage = 20
+  storage_encrypted = false
+
   db_engine = "postgres"
   db_engine_version = "16.4"
-  db_identifier = "auth-token-generator-staging-db"
-  db_instance_class = "db.t3.micro"
-  db_name = "auth_token_generator_db"
-  db_port  = 5102
   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
   db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
-  subnet_ids = data.aws_subnet_ids.staging.ids
-  db_allocated_storage = 20
-  maintenance_window ="sun:10:00-sun:10:30"
-  storage_encrypted = false
-  multi_az = false //only true if production deployment
-  publicly_accessible = false
-  project_name = "platform apis"
+  db_name = "auth_token_generator_db"
+  db_port  = 5102
+
   copy_tags_to_snapshot = true
+  maintenance_window ="sun:10:00-sun:10:30"
+
   additional_tags = {
     BackupPolicy = "Stg"
   }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -69,7 +69,7 @@ module "postgres_db_staging" {
   storage_encrypted = false
 
   db_engine = "postgres"
-  db_engine_version = "16.4"
+  db_engine_version = "16.8"
   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
   db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
   db_name = "auth_token_generator_db"


### PR DESCRIPTION
# What:
 - Resolved the Terraform `cloud_env <--> config` drift of Postgres engine versions across `staging` and `production` environments.
 - Bumped the not yet deployed `development` database's config to engine version `16.8` to match the other currently deployed environments.
 - Matched the formatting of the postgresql module within tf files.

# Why:
 - It's not possible to deploy the database with the engine version `16.4` due to it not longer being available _(see error in **figure 1**)_.
 - Matched the database module formatting so it's easier to compare the config differences between the environments.

# Screenshots:
| <img width="1113" height="142" alt="image" src="https://github.com/user-attachments/assets/2f395ce4-ccba-4f23-80f9-52f6a2e812d7" />|
| --- |
| **Figure 1.** The database deployment error preventing the use of 16.4 engine version |