### PR TITLE
Add SSM Parameter Store key for `development` postgres database's endpoint url.

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -88,3 +88,14 @@ module "postgres_db_development" {
     BackupPolicy = "Dev"
   }
 }
+
+resource "aws_ssm_parameter" "postgres_hostname" {
+  name  = "/api-auth-token-generator/development/postgres-hostname"
+  type  = "String" 
+  
+  value = module.postgres_db_development.db_instance_endpoint 
+
+  tags = {
+    Project     = "platform apis"
+  }
+}


### PR DESCRIPTION
# What:
 - Add SSM Parameter Store key for `development` postgres database's endpoint url.

# Why:
 - So this doesn't need to be done manually. It's going to be used to construct connection strings.