### PR TITLE
Attempt to add network rule to permit jumpbox traffic into the token database.

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -33,6 +33,8 @@ data "aws_region" "current" {}
 locals {
   application_name = "auth token generator api"
   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+
+  token_db_port = 5101
 }
 
 /*    POSTGRES SET UP    */
@@ -79,7 +81,7 @@ module "postgres_db_development" {
   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
   db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
   db_name = "auth_token_generator_db"
-  db_port  = 5101
+  db_port  = locals.token_db_port
 
   copy_tags_to_snapshot = true
   maintenance_window ="sun:10:00-sun:10:30"
@@ -98,4 +100,13 @@ resource "aws_ssm_parameter" "postgres_hostname" {
   tags = {
     Project     = "platform apis"
   }
+}
+
+resource "aws_security_group_rule" "allow_jumpbox_traffic" {
+  type              = "ingress"
+  from_port         = locals.token_db_port
+  to_port           = locals.token_db_port
+  protocol          = "tcp"
+  source_security_group_id = "sg-0a457bf4e6eda31de"
+  security_group_id = module.postgres_db_development.db_security_group_id
 }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -81,7 +81,7 @@ module "postgres_db_development" {
   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
   db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
   db_name = "auth_token_generator_db"
-  db_port  = locals.token_db_port
+  db_port  = local.token_db_port
 
   copy_tags_to_snapshot = true
   maintenance_window ="sun:10:00-sun:10:30"
@@ -104,8 +104,8 @@ resource "aws_ssm_parameter" "postgres_hostname" {
 
 resource "aws_security_group_rule" "allow_jumpbox_traffic" {
   type              = "ingress"
-  from_port         = locals.token_db_port
-  to_port           = locals.token_db_port
+  from_port         = local.token_db_port
+  to_port           = local.token_db_port
   protocol          = "tcp"
   source_security_group_id = "sg-0a457bf4e6eda31de"
   security_group_id = module.postgres_db_development.db_security_group_id


### PR DESCRIPTION
# What:
 - Add a network rule into the token database's security group to permit jumpbox traffic.

# Why:
 - The default ingress rule `0.0.0.0/0` created by the shared postgres rds module gets automatically deleted by cloud custodian rules _(see PR [aws-hackney-common-terraform#78](https://github.com/LBHackney-IT/aws-hackney-common-terraform/pull/78))_.