### PR TITLE
Add Terraform previews to `development` and `master` branch flows.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,8 +359,13 @@ workflows:
       - assume-role-production:
           context: api-assume-role-production-context
           requires: [ deploy-production-infrastructure ]
-      - terraform-init-and-apply-to-production:
+      - preview-terraform-production:
           requires: [ assume-role-production ]
+      - permit-terraform-deployment-to-production:
+          type: approval
+          requires: [ preview-terraform-production ]
+      - terraform-init-and-apply-to-production:
+          requires: [ permit-terraform-deployment-to-production ]
       
 
   development-deployment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,8 +329,13 @@ workflows:
       - assume-role-development:
           context: api-assume-role-development-context
           requires: [ deploy-development-infrastructure ]
-      - terraform-init-and-apply-to-development:
+      - preview-terraform-development:
           requires: [ assume-role-development ]
+      - permit-terraform-deployment-to-dev:
+          type: approval
+          requires: [ preview-terraform-development ]
+      - terraform-init-and-apply-to-development:
+          requires: [ permit-terraform-deployment-to-dev ]
       - deploy-staging-infrastructure:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,11 +331,11 @@ workflows:
           requires: [ deploy-development-infrastructure ]
       - preview-terraform-development:
           requires: [ assume-role-development ]
-      - permit-terraform-deployment-to-dev:
+      - permit-terraform-deployment-to-development:
           type: approval
           requires: [ preview-terraform-development ]
       - terraform-init-and-apply-to-development:
-          requires: [ permit-terraform-deployment-to-dev ]
+          requires: [ permit-terraform-deployment-to-development ]
       - deploy-staging-infrastructure:
           type: approval
           filters:
@@ -344,8 +344,13 @@ workflows:
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires: [ deploy-staging-infrastructure ]
-      - terraform-init-and-apply-to-staging:
+      - preview-terraform-staging:
           requires: [ assume-role-staging ]
+      - permit-terraform-deployment-to-staging:
+          type: approval
+          requires: [ preview-terraform-staging ]
+      - terraform-init-and-apply-to-staging:
+          requires: [ permit-terraform-deployment-to-staging ]
       - deploy-production-infrastructure:
           type: approval
           filters:


### PR DESCRIPTION
# What:
 - Add Terraform previews to `master` and `development` branch workflows.

# Why:
 - Despite being able to preview the changes from the feature branch, by the time the PR gets merged to to one of the main branches, another PR may have been pushed. Or by the time release got permitted, other state might have changed.  Under these circumstances the current workflow offers no insight, and forces doing the infrastructure releases blind. To prevent this another preview is added before the release to decrease the time gap between the feature branch previews and the actual releases.