### PR TITLE
Fix `development` serverless deployment & bump the pipeline's node version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,11 +85,7 @@ commands:
       - *attach_workspace
       - checkout
       - setup_remote_docker
-      - run:
-          name: Install Node.js
-          command: |
-            curl -sL https://deb.nodesource.com/setup_22.x | bash -
-            apt-get update && apt-get install -y nodejs
+      - node/install
       - run:
           name: Install serverless CLI
           command: npm i -g serverless

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ workflows:
           requires: [ permit-terraform-deployment-to-production ]
       
 
-  development-deployment:
+  deployment-api-aplication:
     jobs:
       - check-code-formatting:
           filters:
@@ -387,9 +387,6 @@ workflows:
       - deploy-to-development:
           context: [ "Serverless Framework" ]
           requires: [ migrate-database-development ]
-
-  staging-and-production-deployment:
-    jobs:
       - build-and-test:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,14 +372,14 @@ workflows:
           filters:
             branches:
               only: development
-      - build-and-test-development:
-          job: build-and-test
+      - build-and-test:
+          name: "Build and test development"
           filters:
             branches:
               only: development
       - start-development-deployment:
           type: approval
-          requires: [ build-and-test ]
+          requires: [ "Build and test development" ]
       - assume-role-development:
           context: api-assume-role-development-context
           requires: [ start-development-deployment ]
@@ -388,14 +388,14 @@ workflows:
       - deploy-to-development:
           context: [ "Serverless Framework" ]
           requires: [ migrate-database-development ]
-      - build-and-test-master:
-          job: build-and-test
+      - build-and-test:
+          name: "Build and test master"
           filters:
             branches:
               only: master
       - start-staging-deployment:
           type: approval
-          requires: [ build-and-test ]
+          requires: [ "Build and test master" ]
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires: [ start-staging-deployment ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@5.4.1
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
+  node: circleci/node@7.2.1
 
 executors:
   docker-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,6 +385,7 @@ workflows:
       - migrate-database-development:
           requires: [ assume-role-development ]
       - deploy-to-development:
+          context: [ "Serverless Framework" ]
           requires: [ migrate-database-development ]
 
   staging-and-production-deployment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,8 @@ workflows:
           filters:
             branches:
               only: development
-      - build-and-test:
+      - build-and-test-development:
+          job: build-and-test
           filters:
             branches:
               only: development
@@ -387,7 +388,8 @@ workflows:
       - deploy-to-development:
           context: [ "Serverless Framework" ]
           requires: [ migrate-database-development ]
-      - build-and-test:
+      - build-and-test-master:
+          job: build-and-test
           filters:
             branches:
               only: master


### PR DESCRIPTION
# What:
 - Bump the CCI pipeline's node version to the current active LTS (v24).
 - Switch to managing pipeline node versions via the CCI node orb instead.
 - Add missing Serverless V4 CCI context for the `development` API deployment job.
 - Join API deployment workflows into single workflow.

# Why:
 - Grouping jobs into workflows by what they do makes pipeline easier to navigate.
 - Switched to node orb version management so the pipeline keeps on switching to latest LTS on its own.
 - Add missing Serverless V4 context so the pipeline can log in to deploy the application.