### PR TITLE
Remove artificial double-quotes around SSM Parameter Store values.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ commands:
             USERNAME=$(aws ssm get-parameter --name /api-auth-token-generator/<<parameters.stage>>/postgres-username --query Parameter.Value)
             DATABASE=$(aws ssm get-parameter --name /api-auth-token-generator/<<parameters.stage>>/postgres-database --query Parameter.Value)
             DOTNET_CONN_STR="Host=localhost;Password=${PASSWORD};Port=5432;Username=${USERNAME};Database=${DATABASE}"
-            PSQL_CONN_STR="host=localhost password=${PASSWORD} port=5432 user=${USERNAME} dbname=${DATABASE}"
+            PSQL_CONN_STR="host=localhost password=${PASSWORD//\"} port=5432 user=${USERNAME//\"} dbname=${DATABASE//\"}"
             cd ./TokenAdministrationApi/
 
             if [ "<<parameters.stage>>" = "development" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ workflows:
           requires: [ permit-terraform-deployment-to-production ]
       
 
-  deployment-api-aplication:
+  deploy-api-code:
     jobs:
       - check-code-formatting:
           filters:


### PR DESCRIPTION
# What:
 - Trim the double quotes surrounding the parameter stored values.

# Why:
 - The `aws ssm get-parameter` call with `--query Parameter.Value` adds `"` around the values it pulls. When putting this into psql connection string directly this causes psql to interpret quotes as part of the value.

# Notes:
 - Also renamed the code workflow to be clearer for what it does so it's easier to find in CCI explorer.
 - This PR is an extension of PR #46 .