### PR TITLE
Remove the one-off staging and production migrations skip script.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,21 +147,9 @@ commands:
             USERNAME=$(aws ssm get-parameter --name /api-auth-token-generator/<<parameters.stage>>/postgres-username --query Parameter.Value)
             DATABASE=$(aws ssm get-parameter --name /api-auth-token-generator/<<parameters.stage>>/postgres-database --query Parameter.Value)
             DOTNET_CONN_STR="Host=localhost;Password=${PASSWORD};Port=5432;Username=${USERNAME};Database=${DATABASE}"
-            PSQL_CONN_STR="host=localhost password=${PASSWORD//\"} port=5432 user=${USERNAME//\"} dbname=${DATABASE//\"}"
             cd ./TokenAdministrationApi/
-
-            if [ "<<parameters.stage>>" = "development" ]; then
-              echo "Development environment detected. Attempting migration."
-              CONNECTION_STRING=${DOTNET_CONN_STR} ./../dotnet-ef-local/dotnet-ef database update
-              echo "Migration complete."
-            else
-              echo "Staging or Production environment detected. Marking the migration as complete"
-              MIGRATION_NAME="20251125171927_AddApiGatewayIdToApiLookup"
-              PRODUCT_VERSION="8.0.11"
-              SQL_COMMAND="INSERT INTO \"__EFMigrationsHistory\" (\"MigrationId\", \"ProductVersion\") VALUES ('${MIGRATION_NAME}', '${PRODUCT_VERSION}');"
-              psql "${PSQL_CONN_STR}" -c "${SQL_COMMAND}"
-              echo "Migration successfully registered as complete."
-            fi
+            CONNECTION_STRING=${DOTNET_CONN_STR} ./../dotnet-ef-local/dotnet-ef database update
+            echo "Migration complete."
 
 jobs:
   check-code-formatting:


### PR DESCRIPTION
# What:
 - Clean up the `staging` and `production` environment portion of the script to mark the latest migration as complete.

# Why:
 - It 's a single-run script that has done it's job. The migrations table has been updated in both environment.