### PR TITLE
Use a single value to create the database within postgres server, and…

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -35,6 +35,7 @@ locals {
   parameter_store   = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 
   token_db_port     = 5101
+  token_db_name     = "auth_token_generator_db"
   jumpbox_sg_id     = "sg-0a457bf4e6eda31de"
   token_api_sg_id   = "sg-038858c252a355ffa"
 }
@@ -82,8 +83,8 @@ module "postgres_db_development" {
   db_engine_version = "16.8"
   db_username = data.aws_ssm_parameter.auth_token_generator_postgres_username.value
   db_password = data.aws_ssm_parameter.auth_token_generator_postgres_password.value
-  db_name = "auth_token_generator_db"
-  db_port  = local.token_db_port
+  db_name   = local.token_db_name
+  db_port   = local.token_db_port
 
   copy_tags_to_snapshot = true
   maintenance_window ="sun:10:00-sun:10:30"
@@ -98,6 +99,17 @@ resource "aws_ssm_parameter" "postgres_hostname" {
   type  = "String" 
   
   value = module.postgres_db_development.db_instance_endpoint 
+
+  tags = {
+    Project     = "platform apis"
+  }
+}
+
+resource "aws_ssm_parameter" "postgres_database" {
+  name  = "/api-auth-token-generator/development/postgres-database"
+  type  = "String" 
+  
+  value = local.token_db_name
 
   tags = {
     Project     = "platform apis"


### PR DESCRIPTION
# What:
 - Define the local for the postgres database name.
 - Use that postgres name local for both creating RDS database, and populating the ssm parameter.

# Why:
 - To prevent the connection string variables from being out of sync with the database configuration.