### PR TITLE
Add ingress rule to allow new authorizer's traffic into token database.

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -34,10 +34,11 @@ locals {
   application_name  = "auth token generator api"
   parameter_store   = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 
-  token_db_port     = 5101
-  token_db_name     = "auth_token_generator_db"
-  jumpbox_sg_id     = "sg-0a457bf4e6eda31de"
-  token_api_sg_id   = "sg-038858c252a355ffa"
+  token_db_port         = 5101
+  token_db_name         = "auth_token_generator_db"
+  jumpbox_sg_id         = "sg-0a457bf4e6eda31de"
+  token_api_sg_id       = "sg-038858c252a355ffa"
+  new_authorizer_sg_id  = "sg-012c8d9cacad91fcb"
 }
 
 /*    POSTGRES SET UP    */

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -134,3 +134,12 @@ resource "aws_security_group_rule" "allow_token_api_traffic" {
   source_security_group_id = local.token_api_sg_id
   security_group_id = module.postgres_db_development.db_security_group_id
 }
+
+resource "aws_security_group_rule" "allow_new_authorizer_traffic" {
+  type              = "ingress"
+  from_port         = local.token_db_port
+  to_port           = local.token_db_port
+  protocol          = "tcp"
+  source_security_group_id = local.new_authorizer_sg_id
+  security_group_id = module.postgres_db_development.db_security_group_id
+}


### PR DESCRIPTION
# What:
 - Add an ingress rule to allow new authorizer's traffic into the token database.

# Why:
 - So that our new authorizer would be able to backwards-support the legacy service authentication flow, which requires access to that token database.

# Notes:
 - If GitGuardian complains about this PR as well, it's again due to security group ids variable values. Hence, false positives.