### PR TITLE
EPA project: Add API and endpoint configuration creation endpoints and lookups.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,6 @@ commands:
             cd ./TokenAdministrationApi/
             sls deploy --stage <<parameters.stage>> --conceal
 
-
   migrate-database:
     description: "Migrate database"
     parameters:
@@ -275,199 +274,199 @@ jobs:
           stage: "pre-production"
 
 workflows:
-  feature:
-    jobs:
-      - check-code-formatting:
-          filters:
-            branches:
-              ignore: [ development, master ]
-      - build-and-test:
-          requires: [ check-code-formatting ]
-      - assume-role-development:
-          context: api-assume-role-development-context
-          filters:
-            branches:
-              ignore: [ development, master ]
-      - preview-terraform-development:
-          requires: [ assume-role-development ]
-      - assume-role-staging:
-          context: api-assume-role-staging-context
-          filters:
-            branches:
-              ignore: [ development, master ]
-      - preview-terraform-staging:
-          requires: [ assume-role-staging ]
-      - assume-role-production:
-          context: api-assume-role-production-context
-          filters:
-            branches:
-              ignore: [ development, master ]
-      - preview-terraform-production:
-          requires: [ assume-role-production ]
+  # feature:
+  #   jobs:
+  #     - check-code-formatting:
+  #         filters:
+  #           branches:
+  #             ignore: [ development, master ]
+  #     - build-and-test:
+  #         requires: [ check-code-formatting ]
+  # - assume-role-development:
+  #     context: api-assume-role-development-context
+  #     filters:
+  #       branches:
+  #         ignore: [ development, master ]
+  # - preview-terraform-development:
+  #     requires: [ assume-role-development ]
+  # - assume-role-staging:
+  #     context: api-assume-role-staging-context
+  #     filters:
+  #       branches:
+  #         ignore: [ development, master ]
+  # - preview-terraform-staging:
+  #     requires: [ assume-role-staging ]
+  # - assume-role-production:
+  #     context: api-assume-role-production-context
+  #     filters:
+  #       branches:
+  #         ignore: [ development, master ]
+  # - preview-terraform-production:
+  #     requires: [ assume-role-production ]
 
-  deploy-infrastructure:
-    jobs:
-      - deploy-development-infrastructure:
-          type: approval
-          filters:
-            branches:
-              only: development
-      - assume-role-development:
-          context: api-assume-role-development-context
-          requires: [ deploy-development-infrastructure ]
-      - preview-terraform-development:
-          requires: [ assume-role-development ]
-      - permit-terraform-deployment-to-development:
-          type: approval
-          requires: [ preview-terraform-development ]
-      - terraform-init-and-apply-to-development:
-          requires: [ permit-terraform-deployment-to-development ]
-      - deploy-staging-infrastructure:
-          type: approval
-          filters:
-            branches:
-              only: master
-      - assume-role-staging:
-          context: api-assume-role-staging-context
-          requires: [ deploy-staging-infrastructure ]
-      - preview-terraform-staging:
-          requires: [ assume-role-staging ]
-      - permit-terraform-deployment-to-staging:
-          type: approval
-          requires: [ preview-terraform-staging ]
-      - terraform-init-and-apply-to-staging:
-          requires: [ permit-terraform-deployment-to-staging ]
-      - deploy-production-infrastructure:
-          type: approval
-          filters:
-            branches:
-              only: master
-      - assume-role-production:
-          context: api-assume-role-production-context
-          requires: [ deploy-production-infrastructure ]
-      - preview-terraform-production:
-          requires: [ assume-role-production ]
-      - permit-terraform-deployment-to-production:
-          type: approval
-          requires: [ preview-terraform-production ]
-      - terraform-init-and-apply-to-production:
-          requires: [ permit-terraform-deployment-to-production ]
-      
+  # deploy-infrastructure:
+  #   jobs:
+  #     - deploy-development-infrastructure:
+  #         type: approval
+  #         filters:
+  #           branches:
+  #             only: development
+  #     - assume-role-development:
+  #         context: api-assume-role-development-context
+  #         requires: [ deploy-development-infrastructure ]
+  #     - preview-terraform-development:
+  #         requires: [ assume-role-development ]
+  #     - permit-terraform-deployment-to-development:
+  #         type: approval
+  #         requires: [ preview-terraform-development ]
+  #     - terraform-init-and-apply-to-development:
+  #         requires: [ permit-terraform-deployment-to-development ]
+  #     - deploy-staging-infrastructure:
+  #         type: approval
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - assume-role-staging:
+  #         context: api-assume-role-staging-context
+  #         requires: [ deploy-staging-infrastructure ]
+  #     - preview-terraform-staging:
+  #         requires: [ assume-role-staging ]
+  #     - permit-terraform-deployment-to-staging:
+  #         type: approval
+  #         requires: [ preview-terraform-staging ]
+  #     - terraform-init-and-apply-to-staging:
+  #         requires: [ permit-terraform-deployment-to-staging ]
+  #     - deploy-production-infrastructure:
+  #         type: approval
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - assume-role-production:
+  #         context: api-assume-role-production-context
+  #         requires: [ deploy-production-infrastructure ]
+  #     - preview-terraform-production:
+  #         requires: [ assume-role-production ]
+  #     - permit-terraform-deployment-to-production:
+  #         type: approval
+  #         requires: [ preview-terraform-production ]
+  #     - terraform-init-and-apply-to-production:
+  #         requires: [ permit-terraform-deployment-to-production ]
 
   deploy-api-code:
     jobs:
       - check-code-formatting:
           filters:
             branches:
-              only: development
+              only: tokenrequest
       - build-and-test:
           name: "Build and test development"
-          filters:
-            branches:
-              only: development
+          # filters:
+          #   branches:
+          #     only: development
       - start-development-deployment:
           type: approval
-          requires: [ "Build and test development" ]
+          requires: ["Build and test development"]
       - assume-role-development:
           context: api-assume-role-development-context
-          requires: [ start-development-deployment ]
-      - migrate-database-development:
-          requires: [ assume-role-development ]
+          requires: [start-development-deployment]
+      # - migrate-database-development:
+      #     requires: [ assume-role-development ]
       - deploy-to-development:
-          context: [ "Serverless Framework" ]
-          requires: [ migrate-database-development ]
-      - build-and-test:
-          name: "Build and test master"
-          filters:
-            branches:
-              only: master
-      - start-staging-deployment:
-          type: approval
-          requires: [ "Build and test master" ]
-      - assume-role-staging:
-          context: api-assume-role-staging-context
-          requires: [ start-staging-deployment ]
-      - migrate-database-staging:
-          requires: [ assume-role-staging ]
-      - deploy-to-staging:
-          context: [ "Serverless Framework" ]
-          requires: [ migrate-database-staging ]
-      - start-production-release:
-          type: approval
-          requires: [ deploy-to-staging ]
-      - assume-role-production:
-          context: api-assume-role-production-context
-          requires: [ start-production-release ]
-      - migrate-database-production:
-          requires: [ assume-role-production ]
-      - deploy-to-production:
-          context: [ "Serverless Framework" ]
-          requires: [ migrate-database-production ]
+          context: ["Serverless Framework"]
+          # requires: [ migrate-database-development ]
+          requires: [assume-role-development]
+      # - build-and-test:
+      #     name: "Build and test master"
+      #     filters:
+      #       branches:
+      #         only: master
+      # - start-staging-deployment:
+      #     type: approval
+      #     requires: [ "Build and test master" ]
+      # - assume-role-staging:
+      #     context: api-assume-role-staging-context
+      #     requires: [ start-staging-deployment ]
+      # - migrate-database-staging:
+      #     requires: [ assume-role-staging ]
+      # - deploy-to-staging:
+      #     context: [ "Serverless Framework" ]
+      #     requires: [ migrate-database-staging ]
+      # - start-production-release:
+      #     type: approval
+      #     requires: [ deploy-to-staging ]
+      # - assume-role-production:
+      #     context: api-assume-role-production-context
+      #     requires: [ start-production-release ]
+      # - migrate-database-production:
+      #     requires: [ assume-role-production ]
+      # - deploy-to-production:
+      #     context: [ "Serverless Framework" ]
+      #     requires: [ migrate-database-production ]
 
-  deploy-terraform-pre-production:
-    jobs:
-      - permit-pre-production-terraform-workflow:
-          type: approval
-          filters:
-            branches:
-              only: master
-      - assume-role-pre-production:
-          context: api-assume-role-housing-pre-production-context
-          requires:
-            - permit-pre-production-terraform-workflow
-          filters:
-            branches:
-              only: master
-      - terraform-init-and-plan-pre-production:
-          requires:
-            - assume-role-pre-production
-          filters:
-            branches:
-              only: master
-      - permit-pre-production-terraform-deployment:
-          type: approval
-          requires:
-            - terraform-init-and-plan-pre-production
-          filters:
-            branches:
-              only: master
-      - terraform-apply-pre-production:
-          requires:
-            - permit-pre-production-terraform-deployment
-          filters:
-            branches:
-              only: master
-  deploy-code-pre-production:
-    jobs:
-      - permit-pre-production-code-workflow:
-          type: approval
-          filters:
-            branches:
-              only: master
-      - build-and-test:
-          requires:
-            - permit-pre-production-code-workflow
-          filters:
-            branches:
-              only: master
-      - assume-role-pre-production:
-          context: api-assume-role-housing-pre-production-context
-          requires:
-            - build-and-test
-          filters:
-            branches:
-              only: master
-      - migrate-database-pre-production:
-          requires:
-            - assume-role-pre-production
-          filters:
-            branches:
-              only: master
-      - deploy-to-pre-production:
-          context:
-            - "Serverless Framework"
-          requires:
-            - migrate-database-pre-production
-          filters:
-            branches:
-              only: master
+  # deploy-terraform-pre-production:
+  #   jobs:
+  #     - permit-pre-production-terraform-workflow:
+  #         type: approval
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - assume-role-pre-production:
+  #         context: api-assume-role-housing-pre-production-context
+  #         requires:
+  #           - permit-pre-production-terraform-workflow
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-init-and-plan-pre-production:
+  #         requires:
+  #           - assume-role-pre-production
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - permit-pre-production-terraform-deployment:
+  #         type: approval
+  #         requires:
+  #           - terraform-init-and-plan-pre-production
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-apply-pre-production:
+  #         requires:
+  #           - permit-pre-production-terraform-deployment
+  #         filters:
+  #           branches:
+  #             only: master
+  # deploy-code-pre-production:
+  #   jobs:
+  #     - permit-pre-production-code-workflow:
+  #         type: approval
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - build-and-test:
+  #         requires:
+  #           - permit-pre-production-code-workflow
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - assume-role-pre-production:
+  #         context: api-assume-role-housing-pre-production-context
+  #         requires:
+  #           - build-and-test
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - migrate-database-pre-production:
+  #         requires:
+  #           - assume-role-pre-production
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - deploy-to-pre-production:
+  #         context:
+  #           - "Serverless Framework"
+  #         requires:
+  #           - migrate-database-pre-production
+  #         filters:
+  #           branches:
+  #             only: master

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: setup build serve shell test lint install-ef-tool
+.PHONY: setup build serve shell test lint install-ef-tool migrate-local-dev-database serve-local-dev-database serve-local-dev-api
+LOCAL_DEV_DB_PORT ?= 5434
 
 setup:
 	docker compose build
@@ -15,6 +16,14 @@ shell:
 test:
 	docker compose up test-database & docker compose build token-administration-api-test && docker compose up token-administration-api-test
 
+serve-local-dev-database:
+	LOCAL_DEV_DB_PORT=$(LOCAL_DEV_DB_PORT) docker compose up local-dev-database
+
+migrate-local-dev-database:
+	CONNECTION_STRING="Host=127.0.0.1;Port=$(LOCAL_DEV_DB_PORT);Username=postgres;Password=mypassword;Database=devdb" dotnet ef database update -p TokenAdministrationApi
+
+serve-local-dev-api:
+	LOCAL_DEV_DB_PORT=$(LOCAL_DEV_DB_PORT) docker compose up token-administration-api-dev
 lint:
 	-dotnet tool install -g dotnet-format
 	dotnet tool update -g dotnet-format

--- a/README.md
+++ b/README.md
@@ -98,6 +98,45 @@ Note: The Host name needs to be the name of the stub database docker-compose ser
 - Observable monitoring in place
 - Should not affect any existing databases
 
+## local dev setup
+
+This is useful when you want to run the API in a container with some existing data.
+
+1. start localdb container: `make serve-local-dev-database`
+2. run migrations to get the schema in place: `make migrate-local-dev-database`
+3. get the required lookups in place: connect to the SQL db and run the database/local-dev-seed.sql commands
+4. start the API container:  `make serve-local-dev-api`
+
+API is now running on port 3000.
+
+The local dev database maps to host port `5434` by default to avoid clashing with the test db.
+If `5434` is already in use, override it for all local dev targets, for example:
+
+`LOCAL_DEV_DB_PORT=5435 make serve-local-dev-database`
+
+`LOCAL_DEV_DB_PORT=5435 make migrate-local-dev-database`
+
+`LOCAL_DEV_DB_PORT=5435 make serve-local-dev-api`
+
+It's also configured to persist data, so the container can be safely stopped without losing data.
+
+Sample payload to generate a token:
+
+`POST http://localhost:3000/api/v1/tokens`
+
+``` JSON
+{
+    "requestedBy" : "someones@hackney.gov.uk",
+    "authorizedBy": "someone@hackney.gov.uk",
+    "consumerType": 1,
+    "consumer": "Demo API",
+    "apiName" : 1,
+    "apiEndpoint": 1,
+    "httpMethodType": "GET",
+    "environment": "development",
+    "dateRequested": "2026-03-18"
+}
+```
 ## Contacts
 
 ### Active Maintainers

--- a/TokenAdministrationApi.Tests/V1/Controllers/TokenAdministrationControllerTests.cs
+++ b/TokenAdministrationApi.Tests/V1/Controllers/TokenAdministrationControllerTests.cs
@@ -24,6 +24,7 @@ namespace TokenAdministrationApi.Tests.V1.Controllers
         private Mock<IPostTokenUseCase> _mockPostTokenUseCase;
         private Mock<IGetAllTokensUseCase> _mockGetAllTokensUseCase;
         private Mock<IUpdateTokenValidityUseCase> _updateTokenValidity;
+        private Mock<IGetTokenOptionsUseCase> _getTokenOptionsUseCase;
 
 
         [SetUp]
@@ -32,9 +33,10 @@ namespace TokenAdministrationApi.Tests.V1.Controllers
             _mockGetAllTokensUseCase = new Mock<IGetAllTokensUseCase>();
             _mockPostTokenUseCase = new Mock<IPostTokenUseCase>();
             _updateTokenValidity = new Mock<IUpdateTokenValidityUseCase>();
+            _getTokenOptionsUseCase = new Mock<IGetTokenOptionsUseCase>();
 
             _classUnderTest = new TokenAdministrationApiController(_mockGetAllTokensUseCase.Object, _mockPostTokenUseCase.Object,
-                _updateTokenValidity.Object);
+                _updateTokenValidity.Object, _getTokenOptionsUseCase.Object);
         }
         [Test]
         public void EnsureControllerListTokensMethodCallsGetAllTokensUseCase()
@@ -142,6 +144,67 @@ namespace TokenAdministrationApi.Tests.V1.Controllers
             result.Should().NotBeNull();
             result.StatusCode.Should().Be(400);
             result.Value.Should().Be("One or more of the lookup ids provided is incorrect - foreign key violation message");
+        }
+
+        [Test]
+        public void EnsureControllerGetTokenOptionsMethodCallsUseCase()
+        {
+            var response = new TokenOptionsResponse();
+            _getTokenOptionsUseCase.Setup(x => x.Execute()).Returns(response);
+
+            _classUnderTest.GetTokenOptions();
+
+            _getTokenOptionsUseCase.Verify(x => x.Execute(), Times.Once);
+        }
+
+        [Test]
+        public void ControllerGetTokenOptionsMethodShouldReturnResponseOfTypeTokenOptionsResponse()
+        {
+            var response = new TokenOptionsResponse();
+            _getTokenOptionsUseCase.Setup(x => x.Execute()).Returns(response);
+
+            var result = _classUnderTest.GetTokenOptions() as OkObjectResult;
+
+            result.Should().NotBeNull();
+            result.Value.Should().BeOfType<TokenOptionsResponse>();
+        }
+
+        [Test]
+        public void ControllerGetTokenOptionsMethodShouldReturn200StatusCode()
+        {
+            var response = new TokenOptionsResponse();
+            _getTokenOptionsUseCase.Setup(x => x.Execute()).Returns(response);
+
+            var result = _classUnderTest.GetTokenOptions() as OkObjectResult;
+
+            result.Should().NotBeNull();
+            result.StatusCode.Should().Be(200);
+        }
+
+        [Test]
+        public void ControllerGetTokenOptionsMethodCanReturnTokenOptions()
+        {
+            var expectedResponse = new TokenOptionsResponse
+            {
+                ConsumerTypes = new List<ConsumerTypeOptionResponse>
+                {
+                    new ConsumerTypeOptionResponse { Id = 1, TypeName = "token-options-consumer" }
+                },
+                ApiLookups = new List<ApiLookupOptionResponse>
+                {
+                    new ApiLookupOptionResponse { Id = 1, ApiName = "contracts-api", ApiGatewayId = "gw-test-1234567" }
+                },
+                ApiEndpoints = new List<ApiEndpointOptionResponse>
+                {
+                    new ApiEndpointOptionResponse { Id = 1, ApiLookupId = 1, EndpointName = "/api/v1/token-options-test" }
+                }
+            };
+            _getTokenOptionsUseCase.Setup(x => x.Execute()).Returns(expectedResponse);
+
+            var result = _classUnderTest.GetTokenOptions() as OkObjectResult;
+
+            result.Should().NotBeNull();
+            result.Value.Should().Be(expectedResponse);
         }
     }
 }

--- a/TokenAdministrationApi.Tests/V1/Controllers/TokenAdministrationControllerTests.cs
+++ b/TokenAdministrationApi.Tests/V1/Controllers/TokenAdministrationControllerTests.cs
@@ -25,7 +25,8 @@ namespace TokenAdministrationApi.Tests.V1.Controllers
         private Mock<IGetAllTokensUseCase> _mockGetAllTokensUseCase;
         private Mock<IUpdateTokenValidityUseCase> _updateTokenValidity;
         private Mock<IGetTokenOptionsUseCase> _getTokenOptionsUseCase;
-
+        private Mock<IPostApiUseCase> _postApiUseCase;
+        private Mock<IPostEndpointUseCase> _postEndpointUseCase;
 
         [SetUp]
         public void Setup()
@@ -34,9 +35,11 @@ namespace TokenAdministrationApi.Tests.V1.Controllers
             _mockPostTokenUseCase = new Mock<IPostTokenUseCase>();
             _updateTokenValidity = new Mock<IUpdateTokenValidityUseCase>();
             _getTokenOptionsUseCase = new Mock<IGetTokenOptionsUseCase>();
+            _postApiUseCase = new Mock<IPostApiUseCase>();
+            _postEndpointUseCase = new Mock<IPostEndpointUseCase>();
 
             _classUnderTest = new TokenAdministrationApiController(_mockGetAllTokensUseCase.Object, _mockPostTokenUseCase.Object,
-                _updateTokenValidity.Object, _getTokenOptionsUseCase.Object);
+                _updateTokenValidity.Object, _getTokenOptionsUseCase.Object, _postApiUseCase.Object, _postEndpointUseCase.Object);
         }
         [Test]
         public void EnsureControllerListTokensMethodCallsGetAllTokensUseCase()

--- a/TokenAdministrationApi.Tests/V1/Controllers/TokenAdministrationControllerTests.cs
+++ b/TokenAdministrationApi.Tests/V1/Controllers/TokenAdministrationControllerTests.cs
@@ -209,5 +209,82 @@ namespace TokenAdministrationApi.Tests.V1.Controllers
             result.Should().NotBeNull();
             result.Value.Should().Be(expectedResponse);
         }
+
+        [Test]
+        public void ControllerPostApiMethodShouldReturn201WithCreatedApi()
+        {
+            var request = new CreateApiLookupRequest { ApiName = "housing-api", ApiGatewayId = "gw-housing-dev" };
+            var response = new ApiLookupOptionResponse { Id = 1, ApiName = request.ApiName, ApiGatewayId = request.ApiGatewayId };
+            _postApiUseCase.Setup(x => x.Execute(request)).Returns(response);
+
+            var result = _classUnderTest.PostApi(request) as ObjectResult;
+
+            result.Should().NotBeNull();
+            result.StatusCode.Should().Be(201);
+            result.Value.Should().Be(response);
+        }
+
+        [Test]
+        public void ControllerPostApiMethodShouldReturn409IfApiAlreadyExists()
+        {
+            var request = new CreateApiLookupRequest { ApiName = "housing-api", ApiGatewayId = "gw-housing-dev" };
+            _postApiUseCase.Setup(x => x.Execute(request))
+                .Throws(new DuplicateApiException("API name or gateway ID already exists."));
+
+            var result = _classUnderTest.PostApi(request) as ObjectResult;
+
+            result.Should().NotBeNull();
+            result.StatusCode.Should().Be(409);
+            result.Value.Should().Be("API name or gateway ID already exists.");
+        }
+
+        [Test]
+        public void ControllerPostEndpointMethodShouldReturn201WithCreatedEndpoint()
+        {
+            var apiLookupId = 1;
+            var request = new CreateEndpointRequest { EndpointName = "/tenancies" };
+            var response = new CreateEndpointResponse
+            {
+                Id = 10,
+                ApiLookupId = apiLookupId,
+                ApiName = "housing-api",
+                EndpointName = request.EndpointName
+            };
+            _postEndpointUseCase.Setup(x => x.Execute(apiLookupId, request)).Returns(response);
+
+            var result = _classUnderTest.PostEndpoint(apiLookupId, request) as ObjectResult;
+
+            result.Should().NotBeNull();
+            result.StatusCode.Should().Be(201);
+            result.Value.Should().Be(response);
+        }
+
+        [Test]
+        public void ControllerPostEndpointMethodShouldReturn400IfApiLookupDoesNotExist()
+        {
+            var request = new CreateEndpointRequest { EndpointName = "/tenancies" };
+            _postEndpointUseCase.Setup(x => x.Execute(999, request))
+                .Throws(new LookupValueDoesNotExistException("API lookup was not found."));
+
+            var result = _classUnderTest.PostEndpoint(999, request) as BadRequestObjectResult;
+
+            result.Should().NotBeNull();
+            result.StatusCode.Should().Be(400);
+            result.Value.Should().Be("API lookup was not found.");
+        }
+
+        [Test]
+        public void ControllerPostEndpointMethodShouldReturn409IfEndpointAlreadyExists()
+        {
+            var request = new CreateEndpointRequest { EndpointName = "/tenancies" };
+            _postEndpointUseCase.Setup(x => x.Execute(1, request))
+                .Throws(new DuplicateEndpointException("Endpoint already exists for this API."));
+
+            var result = _classUnderTest.PostEndpoint(1, request) as ObjectResult;
+
+            result.Should().NotBeNull();
+            result.StatusCode.Should().Be(409);
+            result.Value.Should().Be("Endpoint already exists for this API.");
+        }
     }
 }

--- a/TokenAdministrationApi.Tests/V1/E2ETests/GetTokenOptionsIntegrationTests.cs
+++ b/TokenAdministrationApi.Tests/V1/E2ETests/GetTokenOptionsIntegrationTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using TokenAdministrationApi.V1.Boundary.Response;
+using TokenAdministrationApi.V1.Infrastructure;
+
+namespace TokenAdministrationApi.Tests.V1.E2ETests
+{
+    public class GetTokenOptionsIntegrationTests : IntegrationTests<Startup>
+    {
+        [Test]
+        public async Task CanRetrieveTokenOptions()
+        {
+            var consumerType = new ConsumerTypeLookup
+            {
+                TypeName = "token-options-consumer"
+            };
+            DatabaseContext.ConsumerTypeLookups.Add(consumerType);
+            DatabaseContext.SaveChanges();
+
+            var api = new ApiNameLookup
+            {
+                ApiName = "contracts-api",
+                ApiGatewayId = "gw-test-1234567"
+            };
+            DatabaseContext.ApiNameLookups.Add(api);
+            DatabaseContext.SaveChanges();
+
+            var apiEndpoint = new ApiEndpointNameLookup
+            {
+                ApiLookupId = api.Id,
+                ApiEndpointName = "/api/v1/token-options-test"
+            };
+            DatabaseContext.ApiEndpointNameLookups.Add(apiEndpoint);
+            DatabaseContext.SaveChanges();
+
+            var url = new Uri("/api/v1/tokens/options", UriKind.Relative);
+            var response = await Client.GetAsync(url).ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(200);
+
+            var data = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var tokenOptions = JsonConvert.DeserializeObject<TokenOptionsResponse>(data);
+
+            tokenOptions.Should().NotBeNull();
+            tokenOptions.ConsumerTypes.Should().ContainSingle();
+            tokenOptions.ApiLookups.Should().ContainSingle();
+            tokenOptions.ApiEndpoints.Should().ContainSingle();
+
+            tokenOptions.ConsumerTypes[0].TypeName.Should().Be("token-options-consumer");
+            tokenOptions.ApiLookups[0].ApiName.Should().Be("contracts-api");
+            tokenOptions.ApiLookups[0].ApiGatewayId.Should().Be("gw-test-1234567");
+            tokenOptions.ApiEndpoints[0].EndpointName.Should().Be("/api/v1/token-options-test");
+            tokenOptions.ApiEndpoints[0].ApiLookupId.Should().Be(api.Id);
+        }
+    }
+}

--- a/TokenAdministrationApi.Tests/V1/E2ETests/PostApiConfigurationIntegrationTests.cs
+++ b/TokenAdministrationApi.Tests/V1/E2ETests/PostApiConfigurationIntegrationTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using TokenAdministrationApi.V1.Boundary.Requests;
+using TokenAdministrationApi.V1.Boundary.Response;
+using TokenAdministrationApi.V1.Infrastructure;
+
+namespace TokenAdministrationApi.Tests.V1.E2ETests
+{
+    public class PostApiConfigurationIntegrationTests : IntegrationTests<Startup>
+    {
+        [Test]
+        public async Task CanCreateEndpointForApiLookupAsync()
+        {
+            var api = new ApiNameLookup
+            {
+                ApiName = "housing-api",
+                ApiGatewayId = "gw-housing-dev"
+            };
+            DatabaseContext.ApiNameLookups.Add(api);
+            DatabaseContext.SaveChanges();
+
+            var request = new CreateEndpointRequest { EndpointName = "/tenancies" };
+            var content = new StringContent(
+                JsonConvert.SerializeObject(request),
+                Encoding.UTF8,
+                "application/json");
+
+            var response = await Client.PostAsync(
+                new Uri($"/api/v1/tokens/apis/{api.Id}/endpoints", UriKind.Relative),
+                content).ConfigureAwait(true);
+            content.Dispose();
+
+            var data = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var endpointResponse = JsonConvert.DeserializeObject<CreateEndpointResponse>(data);
+
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            endpointResponse.ApiLookupId.Should().Be(api.Id);
+            endpointResponse.ApiName.Should().Be(api.ApiName);
+            endpointResponse.EndpointName.Should().Be(request.EndpointName);
+        }
+    }
+}

--- a/TokenAdministrationApi.Tests/V1/Gateways/TokensGatewayTests.cs
+++ b/TokenAdministrationApi.Tests/V1/Gateways/TokensGatewayTests.cs
@@ -11,6 +11,7 @@ using TokenAdministrationApi.Tests.V1.Helper;
 using TokenAdministrationApi.V1.Domain;
 using System.Collections.Generic;
 using TokenAdministrationApi.V1.Domain.Exceptions;
+using TokenAdministrationApi.V1.Boundary.Response;
 
 namespace TokenAdministrationApi.Tests.V1.Gateways
 {
@@ -213,6 +214,59 @@ namespace TokenAdministrationApi.Tests.V1.Gateways
             testDelegate.Should().Throw<LookupValueDoesNotExistException>();
 
         }
+
+        [Test]
+        public void ShouldGetTokenOptionsFromDatabase()
+        {
+            var consumerType = new ConsumerTypeLookup
+            {
+                Id = 1,
+                TypeName = "token-options-consumer"
+            };
+            var api = new ApiNameLookup
+            {
+                Id = 1,
+                ApiName = "contracts-api",
+                ApiGatewayId = "gw-test-1234567"
+            };
+            var apiEndpoint = new ApiEndpointNameLookup
+            {
+                Id = 1,
+                ApiLookupId = api.Id,
+                ApiEndpointName = "/api/v1/token-options-test"
+            };
+
+            DatabaseContext.ConsumerTypeLookups.Add(consumerType);
+            DatabaseContext.ApiNameLookups.Add(api);
+            DatabaseContext.ApiEndpointNameLookups.Add(apiEndpoint);
+            DatabaseContext.SaveChanges();
+
+            var result = _classUnderTest.GetTokenOptions();
+
+            result.Should().NotBeNull();
+            result.ConsumerTypes.Should().ContainSingle();
+            result.ApiLookups.Should().ContainSingle();
+            result.ApiEndpoints.Should().ContainSingle();
+
+            result.ConsumerTypes[0].Should().BeEquivalentTo(new ConsumerTypeOptionResponse
+            {
+                Id = consumerType.Id,
+                TypeName = consumerType.TypeName
+            });
+            result.ApiLookups[0].Should().BeEquivalentTo(new ApiLookupOptionResponse
+            {
+                Id = api.Id,
+                ApiName = api.ApiName,
+                ApiGatewayId = api.ApiGatewayId
+            });
+            result.ApiEndpoints[0].Should().BeEquivalentTo(new ApiEndpointOptionResponse
+            {
+                Id = apiEndpoint.Id,
+                ApiLookupId = apiEndpoint.ApiLookupId,
+                EndpointName = apiEndpoint.ApiEndpointName
+            });
+        }
+
         private AuthTokens AddTokenLookupValues()
         {
             var fixture = new Fixture();

--- a/TokenAdministrationApi.Tests/V1/Gateways/TokensGatewayTests.cs
+++ b/TokenAdministrationApi.Tests/V1/Gateways/TokensGatewayTests.cs
@@ -267,6 +267,124 @@ namespace TokenAdministrationApi.Tests.V1.Gateways
             });
         }
 
+        [Test]
+        public void CreateApiLookupShouldInsertApiLookupInDatabase()
+        {
+            var request = new CreateApiLookupRequest
+            {
+                ApiName = "housing-api",
+                ApiGatewayId = "gw-housing-dev"
+            };
+
+            var result = _classUnderTest.CreateApiLookup(request);
+
+            var databaseRecord = DatabaseContext.ApiNameLookups.Find(result.Id);
+            databaseRecord.Should().NotBeNull();
+            databaseRecord.ApiName.Should().Be(request.ApiName);
+            databaseRecord.ApiGatewayId.Should().Be(request.ApiGatewayId);
+        }
+
+        [Test]
+        public void CreateApiLookupShouldThrowDuplicateApiExceptionIfNameAlreadyExists()
+        {
+            var existingApi = new ApiNameLookup
+            {
+                ApiName = "housing-api",
+                ApiGatewayId = "gw-housing-dev"
+            };
+            DatabaseContext.ApiNameLookups.Add(existingApi);
+            DatabaseContext.SaveChanges();
+
+            var request = new CreateApiLookupRequest
+            {
+                ApiName = "housing-api",
+                ApiGatewayId = "gw-housing-test"
+            };
+
+            Action createDuplicateApi = () => _classUnderTest.CreateApiLookup(request);
+            createDuplicateApi.Should().Throw<DuplicateApiException>()
+                .WithMessage("API name or gateway ID already exists.");
+        }
+
+        [Test]
+        public void CreateApiLookupShouldThrowDuplicateApiExceptionIfGatewayIdAlreadyExists()
+        {
+            var existingApi = new ApiNameLookup
+            {
+                ApiName = "housing-api",
+                ApiGatewayId = "gw-housing-dev"
+            };
+            DatabaseContext.ApiNameLookups.Add(existingApi);
+            DatabaseContext.SaveChanges();
+
+            var request = new CreateApiLookupRequest
+            {
+                ApiName = "repairs-api",
+                ApiGatewayId = "gw-housing-dev"
+            };
+
+            Action createApiWithDuplicateGatewayId = () => _classUnderTest.CreateApiLookup(request);
+            createApiWithDuplicateGatewayId.Should().Throw<DuplicateApiException>()
+                .WithMessage("API name or gateway ID already exists.");
+        }
+
+        [Test]
+        public void CreateEndpointShouldInsertEndpointForParentApi()
+        {
+            var api = new ApiNameLookup
+            {
+                ApiName = "housing-api",
+                ApiGatewayId = "gw-housing-dev"
+            };
+            DatabaseContext.ApiNameLookups.Add(api);
+            DatabaseContext.SaveChanges();
+
+            var request = new CreateEndpointRequest { EndpointName = "/tenancies" };
+
+            var result = _classUnderTest.CreateEndpoint(api.Id, request);
+
+            var databaseRecord = DatabaseContext.ApiEndpointNameLookups.Find(result.Id);
+            databaseRecord.Should().NotBeNull();
+            databaseRecord.ApiLookupId.Should().Be(api.Id);
+            databaseRecord.ApiEndpointName.Should().Be(request.EndpointName);
+            result.ApiName.Should().Be(api.ApiName);
+        }
+
+        [Test]
+        public void CreateEndpointShouldThrowLookupValueDoesNotExistExceptionIfParentApiDoesNotExist()
+        {
+            var request = new CreateEndpointRequest { EndpointName = "/tenancies" };
+
+            Action createEndpointForMissingApi = () => _classUnderTest.CreateEndpoint(999, request);
+            createEndpointForMissingApi.Should().Throw<LookupValueDoesNotExistException>()
+                .WithMessage("API lookup was not found.");
+        }
+
+        [Test]
+        public void CreateEndpointShouldThrowDuplicateEndpointExceptionIfEndpointAlreadyExistsForApi()
+        {
+            var api = new ApiNameLookup
+            {
+                ApiName = "housing-api",
+                ApiGatewayId = "gw-housing-dev"
+            };
+            DatabaseContext.ApiNameLookups.Add(api);
+            DatabaseContext.SaveChanges();
+
+            DatabaseContext.ApiEndpointNameLookups.Add(new ApiEndpointNameLookup
+            {
+                ApiLookupId = api.Id,
+                ApiEndpointName = "/tenancies"
+            });
+            DatabaseContext.SaveChanges();
+
+            var request = new CreateEndpointRequest { EndpointName = "/tenancies" };
+
+            Action createDuplicateEndpoint = () => _classUnderTest.CreateEndpoint(api.Id, request);
+            createDuplicateEndpoint.Should().Throw<DuplicateEndpointException>()
+                .WithMessage("Endpoint already exists for this API.");
+        }
+
         private AuthTokens AddTokenLookupValues()
         {
             var fixture = new Fixture();

--- a/TokenAdministrationApi.Tests/V1/UseCase/GetTokenOptionsUseCaseTests.cs
+++ b/TokenAdministrationApi.Tests/V1/UseCase/GetTokenOptionsUseCaseTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using TokenAdministrationApi.V1.Boundary.Response;
+using TokenAdministrationApi.V1.Gateways;
+using TokenAdministrationApi.V1.UseCase;
+
+namespace TokenAdministrationApi.Tests.V1.UseCase
+{
+    public class GetTokenOptionsUseCaseTests
+    {
+        private Mock<ITokensGateway> _mockGateway;
+        private GetTokenOptionsUseCase _classUnderTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockGateway = new Mock<ITokensGateway>();
+            _classUnderTest = new GetTokenOptionsUseCase(_mockGateway.Object);
+        }
+
+        [Test]
+        public void EnsureGetTokenOptionsUseCaseCallsGateway()
+        {
+            var response = new TokenOptionsResponse();
+            _mockGateway.Setup(x => x.GetTokenOptions()).Returns(response);
+
+            _classUnderTest.Execute();
+
+            _mockGateway.Verify(x => x.GetTokenOptions(), Times.Once);
+        }
+
+        [Test]
+        public void GetsTokenOptionsFromTheGateway()
+        {
+            var expectedResponse = new TokenOptionsResponse
+            {
+                ConsumerTypes = { new ConsumerTypeOptionResponse { Id = 1, TypeName = "token-options-consumer" } },
+                ApiLookups = { new ApiLookupOptionResponse { Id = 1, ApiName = "contracts-api", ApiGatewayId = "gw-test-1234567" } },
+                ApiEndpoints = { new ApiEndpointOptionResponse { Id = 1, ApiLookupId = 1, EndpointName = "/api/v1/token-options-test" } }
+            };
+            _mockGateway.Setup(x => x.GetTokenOptions()).Returns(expectedResponse);
+
+            _classUnderTest.Execute().Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+}

--- a/TokenAdministrationApi/Properties/launchSettings.json
+++ b/TokenAdministrationApi/Properties/launchSettings.json
@@ -15,7 +15,9 @@
       "launchUrl": "api/v1/healthcheck/ping",
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "jwtSecret": "this_is_a_very_long_secret_key_123456",
+        "CONNECTION_STRING": "Host=localhost;Port=5434;Database=devdb;Username=postgres;Password=mypassword"
       }
     }
   }

--- a/TokenAdministrationApi/Startup.cs
+++ b/TokenAdministrationApi/Startup.cs
@@ -130,6 +130,8 @@ namespace TokenAdministrationApi
             services.AddScoped<IGenerateJwtUseCase, GenerateJwtUseCase>();
             services.AddScoped<IUpdateTokenValidityUseCase, UpdateTokenValidityUseCase>();
             services.AddScoped<IGetTokenOptionsUseCase, GetTokenOptionsUseCase>();
+            services.AddScoped<IPostApiUseCase, PostApiUseCase>();
+
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/TokenAdministrationApi/Startup.cs
+++ b/TokenAdministrationApi/Startup.cs
@@ -129,6 +129,7 @@ namespace TokenAdministrationApi
             services.AddScoped<IPostTokenUseCase, PostTokenUseCase>();
             services.AddScoped<IGenerateJwtUseCase, GenerateJwtUseCase>();
             services.AddScoped<IUpdateTokenValidityUseCase, UpdateTokenValidityUseCase>();
+            services.AddScoped<IGetTokenOptionsUseCase, GetTokenOptionsUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/TokenAdministrationApi/Startup.cs
+++ b/TokenAdministrationApi/Startup.cs
@@ -131,6 +131,7 @@ namespace TokenAdministrationApi
             services.AddScoped<IUpdateTokenValidityUseCase, UpdateTokenValidityUseCase>();
             services.AddScoped<IGetTokenOptionsUseCase, GetTokenOptionsUseCase>();
             services.AddScoped<IPostApiUseCase, PostApiUseCase>();
+            services.AddScoped<IPostEndpointUseCase, PostEndpointUseCase>();
 
         }
 

--- a/TokenAdministrationApi/V1/Boundary/Requests/CreateApiLookupRequest.cs
+++ b/TokenAdministrationApi/V1/Boundary/Requests/CreateApiLookupRequest.cs
@@ -1,0 +1,5 @@
+public class CreateApiLookupRequest
+{
+    public string ApiName { get; set; }
+    public string ApiGatewayId{ get; set; }
+}

--- a/TokenAdministrationApi/V1/Boundary/Requests/CreateApiLookupRequest.cs
+++ b/TokenAdministrationApi/V1/Boundary/Requests/CreateApiLookupRequest.cs
@@ -1,5 +1,8 @@
-public class CreateApiLookupRequest
+namespace TokenAdministrationApi.V1.Boundary.Requests
 {
-    public string ApiName { get; set; }
-    public string ApiGatewayId{ get; set; }
+    public class CreateApiLookupRequest
+    {
+        public string ApiName { get; set; }
+        public string ApiGatewayId { get; set; }
+    }
 }

--- a/TokenAdministrationApi/V1/Boundary/Requests/CreateEndpointRequest.cs
+++ b/TokenAdministrationApi/V1/Boundary/Requests/CreateEndpointRequest.cs
@@ -2,7 +2,6 @@ namespace TokenAdministrationApi.V1.Boundary.Requests
 {
     public class CreateEndpointRequest
     {
-        public int ApiLookupId { get; set; }
         public string EndpointName { get; set; }
     }
 }

--- a/TokenAdministrationApi/V1/Boundary/Requests/CreateEndpointRequest.cs
+++ b/TokenAdministrationApi/V1/Boundary/Requests/CreateEndpointRequest.cs
@@ -1,0 +1,8 @@
+namespace TokenAdministrationApi.V1.Boundary.Requests
+{
+    public class CreateEndpointRequest
+    {
+        public int ApiLookupId { get; set; }
+        public string EndpointName { get; set; }
+    }
+}

--- a/TokenAdministrationApi/V1/Boundary/Response/CreateEndpointResponse.cs
+++ b/TokenAdministrationApi/V1/Boundary/Response/CreateEndpointResponse.cs
@@ -1,0 +1,10 @@
+namespace TokenAdministrationApi.V1.Boundary.Response
+{
+    public class CreateEndpointResponse
+    {
+        public int Id { get; set; }
+        public int ApiLookupId { get; set; }
+        public string ApiName { get; set; }
+        public string EndpointName { get; set; }
+    }
+}

--- a/TokenAdministrationApi/V1/Boundary/Response/TokenOptionsResponse.cs
+++ b/TokenAdministrationApi/V1/Boundary/Response/TokenOptionsResponse.cs
@@ -1,15 +1,12 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace TokenAdministrationApi.V1.Boundary.Response
 {
     public class TokenOptionsResponse
     {
-        public List<ConsumerTypeOptionResponse> ConsumerTypes { get; set; } = new();
-        public List<ApiLookupOptionResponse> ApiLookups { get; set; } = new();
-        public List<ApiEndpointOptionResponse> ApiEndpoints { get; set; } = new();
+        public List<ConsumerTypeOptionResponse> ConsumerTypes { get; set; } = [];
+        public List<ApiLookupOptionResponse> ApiLookups { get; set; } = [];
+        public List<ApiEndpointOptionResponse> ApiEndpoints { get; set; } = [];
     }
 
     public class ConsumerTypeOptionResponse
@@ -32,4 +29,3 @@ namespace TokenAdministrationApi.V1.Boundary.Response
         public string EndpointName { get; set; }
     }
 }
-

--- a/TokenAdministrationApi/V1/Boundary/Response/TokenOptionsResponse.cs
+++ b/TokenAdministrationApi/V1/Boundary/Response/TokenOptionsResponse.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace TokenAdministrationApi.V1.Boundary.Response
+{
+    public class TokenOptionsResponse
+    {
+        public List<ConsumerTypeOptionResponse> ConsumerTypes { get; set; } = new();
+        public List<ApiLookupOptionResponse> ApiLookups { get; set; } = new();
+        public List<ApiEndpointOptionResponse> ApiEndpoints { get; set; } = new();
+    }
+
+    public class ConsumerTypeOptionResponse
+    {
+        public int Id { get; set; }
+        public string TypeName { get; set; }
+    }
+
+    public class ApiLookupOptionResponse
+    {
+        public int Id { get; set; }
+        public string ApiName { get; set; }
+        public string ApiGatewayId { get; set; }
+    }
+
+    public class ApiEndpointOptionResponse
+    {
+        public int Id { get; set; }
+        public int ApiLookupId { get; set; }
+        public string EndpointName { get; set; }
+    }
+}
+

--- a/TokenAdministrationApi/V1/Controllers/TokenAdministrationApiController.cs
+++ b/TokenAdministrationApi/V1/Controllers/TokenAdministrationApiController.cs
@@ -23,15 +23,18 @@ namespace TokenAdministrationApi.V1.Controllers
         private readonly IGetTokenOptionsUseCase _getTokenOptionsUseCase;
         private readonly IPostApiUseCase _postApiUsecase;
 
+        private readonly IPostEndpointUseCase _postEndpointUsecase;
+
 
         public TokenAdministrationApiController(IGetAllTokensUseCase getAllTokensUseCase, IPostTokenUseCase postTokenUseCase,
-            IUpdateTokenValidityUseCase updateTokenValidity, IGetTokenOptionsUseCase tokenOptionsUseCase, IPostApiUseCase postApiUsecase)
+            IUpdateTokenValidityUseCase updateTokenValidity, IGetTokenOptionsUseCase tokenOptionsUseCase, IPostApiUseCase postApiUsecase, IPostEndpointUseCase postEndpointUsecase)
         {
             _getAllTokensUseCase = getAllTokensUseCase;
             _postTokenUseCase = postTokenUseCase;
             _updateTokenValidity = updateTokenValidity;
             _getTokenOptionsUseCase = tokenOptionsUseCase;
             _postApiUsecase = postApiUsecase;
+            _postEndpointUsecase = postEndpointUsecase;
         }
 
         /// <summary>
@@ -99,7 +102,7 @@ namespace TokenAdministrationApi.V1.Controllers
         }
 
         [Consumes(MediaTypeNames.Application.Json)]
-        [ProducesResponseType(typeof(GenerateTokenResponse), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ApiLookupOptionResponse), StatusCodes.Status201Created)]
         [HttpPost("apis")]
         public IActionResult PostApi([FromBody] CreateApiLookupRequest request)
         {
@@ -107,6 +110,18 @@ namespace TokenAdministrationApi.V1.Controllers
             return StatusCode(StatusCodes.Status201Created, response);
 
         }
+
+        [Consumes(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(typeof(ApiLookupOptionResponse), StatusCodes.Status201Created)]
+        [HttpPost("endpoints")]
+        public IActionResult PostEndpoint([FromBody] CreateEndpointRequest request)
+        {
+            var response = _postEndpointUsecase.Execute(request);
+            return StatusCode(StatusCodes.Status201Created, response);
+
+        }
+
+
 
     }
 

--- a/TokenAdministrationApi/V1/Controllers/TokenAdministrationApiController.cs
+++ b/TokenAdministrationApi/V1/Controllers/TokenAdministrationApiController.cs
@@ -106,9 +106,15 @@ namespace TokenAdministrationApi.V1.Controllers
         [HttpPost("apis")]
         public IActionResult PostApi([FromBody] CreateApiLookupRequest request)
         {
-            var response = _postApiUsecase.Execute(request);
-            return StatusCode(StatusCodes.Status201Created, response);
-
+            try
+            {
+                var response = _postApiUsecase.Execute(request);
+                return StatusCode(StatusCodes.Status201Created, response);
+            }
+            catch (DuplicateApiException ex)
+            {
+                return Conflict(ex.Message);
+            }
         }
 
         [Consumes(MediaTypeNames.Application.Json)]

--- a/TokenAdministrationApi/V1/Controllers/TokenAdministrationApiController.cs
+++ b/TokenAdministrationApi/V1/Controllers/TokenAdministrationApiController.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using TokenAdministrationApi.V1.Boundary.Requests;
 using TokenAdministrationApi.V1.Boundary.Request;
 using TokenAdministrationApi.V1.Domain.Exceptions;
+using System.Reflection.Metadata.Ecma335;
 
 namespace TokenAdministrationApi.V1.Controllers
 {
@@ -20,15 +21,17 @@ namespace TokenAdministrationApi.V1.Controllers
         private readonly IPostTokenUseCase _postTokenUseCase;
         private readonly IUpdateTokenValidityUseCase _updateTokenValidity;
         private readonly IGetTokenOptionsUseCase _getTokenOptionsUseCase;
+        private readonly IPostApiUseCase _postApiUsecase;
 
 
         public TokenAdministrationApiController(IGetAllTokensUseCase getAllTokensUseCase, IPostTokenUseCase postTokenUseCase,
-            IUpdateTokenValidityUseCase updateTokenValidity, IGetTokenOptionsUseCase tokenOptionsUseCase)
+            IUpdateTokenValidityUseCase updateTokenValidity, IGetTokenOptionsUseCase tokenOptionsUseCase, IPostApiUseCase postApiUsecase)
         {
             _getAllTokensUseCase = getAllTokensUseCase;
             _postTokenUseCase = postTokenUseCase;
             _updateTokenValidity = updateTokenValidity;
             _getTokenOptionsUseCase = tokenOptionsUseCase;
+            _postApiUsecase = postApiUsecase;
         }
 
         /// <summary>
@@ -95,6 +98,16 @@ namespace TokenAdministrationApi.V1.Controllers
             return Ok(_getTokenOptionsUseCase.Execute());
         }
 
+        [Consumes(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(typeof(GenerateTokenResponse), StatusCodes.Status201Created)]
+        [HttpPost("apis")]
+        public IActionResult PostApi([FromBody] CreateApiLookupRequest request)
+        {
+            var response = _postApiUsecase.Execute(request);
+            return StatusCode(StatusCodes.Status201Created, response);
+
+        }
 
     }
+
 }

--- a/TokenAdministrationApi/V1/Controllers/TokenAdministrationApiController.cs
+++ b/TokenAdministrationApi/V1/Controllers/TokenAdministrationApiController.cs
@@ -3,11 +3,9 @@ using TokenAdministrationApi.V1.Boundary.Response;
 using TokenAdministrationApi.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using TokenAdministrationApi.V1.Boundary.Requests;
 using TokenAdministrationApi.V1.Boundary.Request;
 using TokenAdministrationApi.V1.Domain.Exceptions;
-using System.Reflection.Metadata.Ecma335;
 
 namespace TokenAdministrationApi.V1.Controllers
 {
@@ -22,9 +20,7 @@ namespace TokenAdministrationApi.V1.Controllers
         private readonly IUpdateTokenValidityUseCase _updateTokenValidity;
         private readonly IGetTokenOptionsUseCase _getTokenOptionsUseCase;
         private readonly IPostApiUseCase _postApiUsecase;
-
         private readonly IPostEndpointUseCase _postEndpointUsecase;
-
 
         public TokenAdministrationApiController(IGetAllTokensUseCase getAllTokensUseCase, IPostTokenUseCase postTokenUseCase,
             IUpdateTokenValidityUseCase updateTokenValidity, IGetTokenOptionsUseCase tokenOptionsUseCase, IPostApiUseCase postApiUsecase, IPostEndpointUseCase postEndpointUsecase)

--- a/TokenAdministrationApi/V1/Controllers/TokenAdministrationApiController.cs
+++ b/TokenAdministrationApi/V1/Controllers/TokenAdministrationApiController.cs
@@ -19,13 +19,16 @@ namespace TokenAdministrationApi.V1.Controllers
         private readonly IGetAllTokensUseCase _getAllTokensUseCase;
         private readonly IPostTokenUseCase _postTokenUseCase;
         private readonly IUpdateTokenValidityUseCase _updateTokenValidity;
+        private readonly IGetTokenOptionsUseCase _getTokenOptionsUseCase;
+
 
         public TokenAdministrationApiController(IGetAllTokensUseCase getAllTokensUseCase, IPostTokenUseCase postTokenUseCase,
-            IUpdateTokenValidityUseCase updateTokenValidity)
+            IUpdateTokenValidityUseCase updateTokenValidity, IGetTokenOptionsUseCase tokenOptionsUseCase)
         {
             _getAllTokensUseCase = getAllTokensUseCase;
             _postTokenUseCase = postTokenUseCase;
             _updateTokenValidity = updateTokenValidity;
+            _getTokenOptionsUseCase = tokenOptionsUseCase;
         }
 
         /// <summary>
@@ -84,5 +87,14 @@ namespace TokenAdministrationApi.V1.Controllers
 
             return NoContent();
         }
+
+        [ProducesResponseType(typeof(TokenOptionsResponse), StatusCodes.Status200OK)]
+        [HttpGet("options")]
+        public IActionResult GetTokenOptions()
+        {
+            return Ok(_getTokenOptionsUseCase.Execute());
+        }
+
+
     }
 }

--- a/TokenAdministrationApi/V1/Controllers/TokenAdministrationApiController.cs
+++ b/TokenAdministrationApi/V1/Controllers/TokenAdministrationApiController.cs
@@ -112,17 +112,23 @@ namespace TokenAdministrationApi.V1.Controllers
         }
 
         [Consumes(MediaTypeNames.Application.Json)]
-        [ProducesResponseType(typeof(ApiLookupOptionResponse), StatusCodes.Status201Created)]
-        [HttpPost("endpoints")]
-        public IActionResult PostEndpoint([FromBody] CreateEndpointRequest request)
+        [ProducesResponseType(typeof(CreateEndpointResponse), StatusCodes.Status201Created)]
+        [HttpPost("apis/{apiLookupId}/endpoints")]
+        public IActionResult PostEndpoint(int apiLookupId, [FromBody] CreateEndpointRequest request)
         {
-            var response = _postEndpointUsecase.Execute(request);
-            return StatusCode(StatusCodes.Status201Created, response);
-
+            try
+            {
+                var response = _postEndpointUsecase.Execute(apiLookupId, request);
+                return StatusCode(StatusCodes.Status201Created, response);
+            }
+            catch (LookupValueDoesNotExistException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (DuplicateEndpointException ex)
+            {
+                return Conflict(ex.Message);
+            }
         }
-
-
-
     }
-
 }

--- a/TokenAdministrationApi/V1/Domain/Exceptions/DuplicateApiException.cs
+++ b/TokenAdministrationApi/V1/Domain/Exceptions/DuplicateApiException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace TokenAdministrationApi.V1.Domain.Exceptions
+{
+    public class DuplicateApiException : Exception
+    {
+        public DuplicateApiException(string message)
+            : base(message) { }
+    }
+}

--- a/TokenAdministrationApi/V1/Domain/Exceptions/DuplicateEndpointException.cs
+++ b/TokenAdministrationApi/V1/Domain/Exceptions/DuplicateEndpointException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace TokenAdministrationApi.V1.Domain.Exceptions
+{
+    public class DuplicateEndpointException : Exception
+    {
+        public DuplicateEndpointException(string message)
+            : base(message) { }
+    }
+}

--- a/TokenAdministrationApi/V1/Gateways/ITokensGateway.cs
+++ b/TokenAdministrationApi/V1/Gateways/ITokensGateway.cs
@@ -11,5 +11,7 @@ namespace TokenAdministrationApi.V1.Gateways
         int GenerateToken(TokenRequestObject tokenRequestObject);
         int? UpdateToken(int tokenId, bool enabled);
         TokenOptionsResponse GetTokenOptions();
+
+        ApiLookupOptionResponse CreateApiLookup(CreateApiLookupRequest request);
     }
 }

--- a/TokenAdministrationApi/V1/Gateways/ITokensGateway.cs
+++ b/TokenAdministrationApi/V1/Gateways/ITokensGateway.cs
@@ -13,5 +13,7 @@ namespace TokenAdministrationApi.V1.Gateways
         TokenOptionsResponse GetTokenOptions();
 
         ApiLookupOptionResponse CreateApiLookup(CreateApiLookupRequest request);
+
+         ApiEndpointOptionResponse  CreateEndpoint(CreateEndpointRequest request);
     }
 }

--- a/TokenAdministrationApi/V1/Gateways/ITokensGateway.cs
+++ b/TokenAdministrationApi/V1/Gateways/ITokensGateway.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TokenAdministrationApi.V1.Boundary.Requests;
 using TokenAdministrationApi.V1.Domain;
+using TokenAdministrationApi.V1.Boundary.Response;
 
 namespace TokenAdministrationApi.V1.Gateways
 {
@@ -9,5 +10,6 @@ namespace TokenAdministrationApi.V1.Gateways
         List<AuthToken> GetAllTokens(int limit, int cursor, bool? enabled);
         int GenerateToken(TokenRequestObject tokenRequestObject);
         int? UpdateToken(int tokenId, bool enabled);
+        TokenOptionsResponse GetTokenOptions();
     }
 }

--- a/TokenAdministrationApi/V1/Gateways/ITokensGateway.cs
+++ b/TokenAdministrationApi/V1/Gateways/ITokensGateway.cs
@@ -14,6 +14,6 @@ namespace TokenAdministrationApi.V1.Gateways
 
         ApiLookupOptionResponse CreateApiLookup(CreateApiLookupRequest request);
 
-         ApiEndpointOptionResponse  CreateEndpoint(CreateEndpointRequest request);
+        CreateEndpointResponse CreateEndpoint(int apiLookupId, CreateEndpointRequest request);
     }
 }

--- a/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
+++ b/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
@@ -96,21 +96,15 @@ namespace TokenAdministrationApi.V1.Gateways
                     Id = api.Id,
                     ApiName = api.ApiName,
                     ApiGatewayId = api.ApiGatewayId
-
                 }).ToList(),
                 ApiEndpoints = _databaseContext.ApiEndpointNameLookups.Select(endpoint => new ApiEndpointOptionResponse
                 {
                     Id = endpoint.Id,
                     ApiLookupId = endpoint.ApiLookupId,
                     EndpointName = endpoint.ApiEndpointName
-
                 }).ToList()
-
             };
             return tokenOptions;
-
-
-
         }
 
         public ApiLookupOptionResponse CreateApiLookup(CreateApiLookupRequest request)

--- a/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
+++ b/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
@@ -132,23 +132,39 @@ namespace TokenAdministrationApi.V1.Gateways
             };
         }
 
-        public ApiEndpointOptionResponse CreateEndpoint(CreateEndpointRequest request)
+        public CreateEndpointResponse CreateEndpoint(int apiLookupId, CreateEndpointRequest request)
         {
-            var Endpoint = new ApiEndpointNameLookup
+            var apiLookup = _databaseContext.ApiNameLookups.Find(apiLookupId);
+            if (apiLookup == null)
             {
-                // ApiName = request.ApiName,
-                ApiEndpointName = request.EndpointName
+                throw new LookupValueDoesNotExistException("API lookup was not found.");
+            }
 
+            var endpointName = request.EndpointName.Trim();
+            var endpointAlreadyExists = _databaseContext.ApiEndpointNameLookups.Any(endpoint =>
+                endpoint.ApiLookupId == apiLookupId &&
+                endpoint.ApiEndpointName == endpointName);
+
+            if (endpointAlreadyExists)
+            {
+                throw new DuplicateEndpointException("Endpoint already exists for this API.");
+            }
+
+            var endpoint = new ApiEndpointNameLookup
+            {
+                ApiLookupId = apiLookupId,
+                ApiEndpointName = endpointName
             };
 
-            _databaseContext.ApiEndpointNameLookups.Add(Endpoint);
+            _databaseContext.ApiEndpointNameLookups.Add(endpoint);
             _databaseContext.SaveChanges();
 
-            return new ApiEndpointOptionResponse
+            return new CreateEndpointResponse
             {
-                Id = Endpoint.Id,
-                // ApiName = Endpoint.ApiName,
-                EndpointName = Endpoint.ApiEndpointName
+                Id = endpoint.Id,
+                ApiLookupId = endpoint.ApiLookupId,
+                ApiName = apiLookup.ApiName,
+                EndpointName = endpoint.ApiEndpointName
             };
         }
     }

--- a/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
+++ b/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
@@ -9,8 +9,6 @@ using TokenAdministrationApi.V1.Factories;
 using TokenAdministrationApi.V1.Infrastructure;
 using TokenAdministrationApi.V1.Domain.Exceptions;
 using TokenAdministrationApi.V1.Boundary.Response;
-using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.AspNetCore.Http;
 
 namespace TokenAdministrationApi.V1.Gateways
 {

--- a/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
+++ b/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
@@ -8,6 +8,8 @@ using TokenAdministrationApi.V1.Domain;
 using TokenAdministrationApi.V1.Factories;
 using TokenAdministrationApi.V1.Infrastructure;
 using TokenAdministrationApi.V1.Domain.Exceptions;
+using TokenAdministrationApi.V1.Boundary.Response;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace TokenAdministrationApi.V1.Gateways
 {
@@ -77,6 +79,35 @@ namespace TokenAdministrationApi.V1.Gateways
             token.Enabled = enabled;
             _databaseContext.SaveChanges();
             return token.Id;
+        }
+
+        public TokenOptionsResponse GetTokenOptions()
+        {
+            var tokenOptions = new TokenOptionsResponse
+            {
+                ConsumerTypes = _databaseContext.ConsumerTypeLookups.Select(consumerType => new ConsumerTypeOptionResponse
+                {
+                    Id = consumerType.Id,
+                    TypeName = consumerType.TypeName
+                }).ToList(),
+                ApiLookups =  _databaseContext.ApiNameLookups.Select(api => new ApiLookupOptionResponse
+                {
+                    Id = api.Id,
+                    ApiName = api.ApiName,
+                    ApiGatewayId =api.ApiGatewayId
+                    
+                }).ToList(),
+                     ApiEndpoints =  _databaseContext.ApiEndpointNameLookups.Select(endpoint => new ApiEndpointOptionResponse
+                {
+                    Id = endpoint.Id,
+                    ApiLookupId =  endpoint.ApiLookupId,
+                    EndpointName = endpoint.ApiEndpointName
+                    
+                }).ToList()
+
+             };
+            return tokenOptions;
+
         }
     }
 }

--- a/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
+++ b/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
@@ -90,24 +90,45 @@ namespace TokenAdministrationApi.V1.Gateways
                     Id = consumerType.Id,
                     TypeName = consumerType.TypeName
                 }).ToList(),
-                ApiLookups =  _databaseContext.ApiNameLookups.Select(api => new ApiLookupOptionResponse
+                ApiLookups = _databaseContext.ApiNameLookups.Select(api => new ApiLookupOptionResponse
                 {
                     Id = api.Id,
                     ApiName = api.ApiName,
-                    ApiGatewayId =api.ApiGatewayId
-                    
+                    ApiGatewayId = api.ApiGatewayId
+
                 }).ToList(),
-                     ApiEndpoints =  _databaseContext.ApiEndpointNameLookups.Select(endpoint => new ApiEndpointOptionResponse
+                ApiEndpoints = _databaseContext.ApiEndpointNameLookups.Select(endpoint => new ApiEndpointOptionResponse
                 {
                     Id = endpoint.Id,
-                    ApiLookupId =  endpoint.ApiLookupId,
+                    ApiLookupId = endpoint.ApiLookupId,
                     EndpointName = endpoint.ApiEndpointName
-                    
+
                 }).ToList()
 
-             };
+            };
             return tokenOptions;
 
+
+
+        }
+
+        public ApiLookupOptionResponse CreateApiLookup(CreateApiLookupRequest request)
+        {
+            var apiLookup = new ApiNameLookup
+            {
+                ApiName = request.ApiName,
+                ApiGatewayId = request.ApiGatewayId
+            };
+
+            _databaseContext.ApiNameLookups.Add(apiLookup);
+            _databaseContext.SaveChanges();
+
+            return new ApiLookupOptionResponse
+            {
+                Id = apiLookup.Id,
+                ApiName = apiLookup.ApiName,
+                ApiGatewayId = apiLookup.ApiGatewayId
+            };
         }
     }
 }

--- a/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
+++ b/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
@@ -10,6 +10,7 @@ using TokenAdministrationApi.V1.Infrastructure;
 using TokenAdministrationApi.V1.Domain.Exceptions;
 using TokenAdministrationApi.V1.Boundary.Response;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.AspNetCore.Http;
 
 namespace TokenAdministrationApi.V1.Gateways
 {
@@ -128,6 +129,26 @@ namespace TokenAdministrationApi.V1.Gateways
                 Id = apiLookup.Id,
                 ApiName = apiLookup.ApiName,
                 ApiGatewayId = apiLookup.ApiGatewayId
+            };
+        }
+
+        public ApiEndpointOptionResponse CreateEndpoint(CreateEndpointRequest request)
+        {
+            var Endpoint = new ApiEndpointNameLookup
+            {
+                // ApiName = request.ApiName,
+                ApiEndpointName = request.EndpointName
+
+            };
+
+            _databaseContext.ApiEndpointNameLookups.Add(Endpoint);
+            _databaseContext.SaveChanges();
+
+            return new ApiEndpointOptionResponse
+            {
+                Id = Endpoint.Id,
+                // ApiName = Endpoint.ApiName,
+                EndpointName = Endpoint.ApiEndpointName
             };
         }
     }

--- a/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
+++ b/TokenAdministrationApi/V1/Gateways/TokensGateway.cs
@@ -115,10 +115,22 @@ namespace TokenAdministrationApi.V1.Gateways
 
         public ApiLookupOptionResponse CreateApiLookup(CreateApiLookupRequest request)
         {
+            var apiName = request.ApiName.Trim();
+            var apiGatewayId = request.ApiGatewayId.Trim();
+
+            var apiAlreadyExists = _databaseContext.ApiNameLookups.Any(api =>
+                api.ApiName == apiName ||
+                api.ApiGatewayId == apiGatewayId);
+
+            if (apiAlreadyExists)
+            {
+                throw new DuplicateApiException("API name or gateway ID already exists.");
+            }
+
             var apiLookup = new ApiNameLookup
             {
-                ApiName = request.ApiName,
-                ApiGatewayId = request.ApiGatewayId
+                ApiName = apiName,
+                ApiGatewayId = apiGatewayId
             };
 
             _databaseContext.ApiNameLookups.Add(apiLookup);

--- a/TokenAdministrationApi/V1/UseCase/GetTokenOptionsUseCase.cs
+++ b/TokenAdministrationApi/V1/UseCase/GetTokenOptionsUseCase.cs
@@ -1,0 +1,20 @@
+using TokenAdministrationApi.V1.Boundary.Response;
+using TokenAdministrationApi.V1.Gateways;
+using TokenAdministrationApi.V1.UseCase.Interfaces;
+
+namespace TokenAdministrationApi.V1.UseCase
+{
+   public class GetTokenOptionsUseCase : IGetTokenOptionsUseCase
+    {
+        private readonly ITokensGateway _gateway;
+        public GetTokenOptionsUseCase(ITokensGateway gateway)
+        {
+            _gateway = gateway;
+        }
+        
+        public TokenOptionsResponse Execute()
+        {
+            return _gateway.GetTokenOptions();
+        }
+    }
+}

--- a/TokenAdministrationApi/V1/UseCase/GetTokenOptionsUseCase.cs
+++ b/TokenAdministrationApi/V1/UseCase/GetTokenOptionsUseCase.cs
@@ -4,14 +4,14 @@ using TokenAdministrationApi.V1.UseCase.Interfaces;
 
 namespace TokenAdministrationApi.V1.UseCase
 {
-   public class GetTokenOptionsUseCase : IGetTokenOptionsUseCase
+    public class GetTokenOptionsUseCase : IGetTokenOptionsUseCase
     {
         private readonly ITokensGateway _gateway;
         public GetTokenOptionsUseCase(ITokensGateway gateway)
         {
             _gateway = gateway;
         }
-        
+
         public TokenOptionsResponse Execute()
         {
             return _gateway.GetTokenOptions();

--- a/TokenAdministrationApi/V1/UseCase/Interfaces/IGetTokenOptionsUseCase.cs
+++ b/TokenAdministrationApi/V1/UseCase/Interfaces/IGetTokenOptionsUseCase.cs
@@ -3,7 +3,6 @@ using TokenAdministrationApi.V1.Boundary.Response;
 namespace TokenAdministrationApi.V1.UseCase.Interfaces
 {
     public interface IGetTokenOptionsUseCase
-
     {
         TokenOptionsResponse Execute();
     }

--- a/TokenAdministrationApi/V1/UseCase/Interfaces/IGetTokenOptionsUseCase.cs
+++ b/TokenAdministrationApi/V1/UseCase/Interfaces/IGetTokenOptionsUseCase.cs
@@ -1,0 +1,10 @@
+using TokenAdministrationApi.V1.Boundary.Response;
+
+namespace TokenAdministrationApi.V1.UseCase.Interfaces
+{
+    public interface IGetTokenOptionsUseCase
+
+    {
+        TokenOptionsResponse Execute();
+    }
+}

--- a/TokenAdministrationApi/V1/UseCase/Interfaces/IPostApiUseCase.cs
+++ b/TokenAdministrationApi/V1/UseCase/Interfaces/IPostApiUseCase.cs
@@ -1,0 +1,10 @@
+using TokenAdministrationApi.V1.Boundary.Requests;
+using TokenAdministrationApi.V1.Boundary.Response;
+
+namespace TokenAdministrationApi.V1.UseCase.Interfaces
+{
+    public interface IPostApiUseCase
+    {
+        ApiLookupOptionResponse Execute(CreateApiLookupRequest request);
+    }
+}

--- a/TokenAdministrationApi/V1/UseCase/Interfaces/IPostEndpointUseCase.cs
+++ b/TokenAdministrationApi/V1/UseCase/Interfaces/IPostEndpointUseCase.cs
@@ -5,6 +5,6 @@ namespace TokenAdministrationApi.V1.UseCase.Interfaces
 {
     public interface IPostEndpointUseCase
     {
-         ApiEndpointOptionResponse Execute(CreateEndpointRequest request);
+        CreateEndpointResponse Execute(int apiLookupId, CreateEndpointRequest request);
     }
 }

--- a/TokenAdministrationApi/V1/UseCase/Interfaces/IPostEndpointUseCase.cs
+++ b/TokenAdministrationApi/V1/UseCase/Interfaces/IPostEndpointUseCase.cs
@@ -1,0 +1,10 @@
+using TokenAdministrationApi.V1.Boundary.Requests;
+using TokenAdministrationApi.V1.Boundary.Response;
+
+namespace TokenAdministrationApi.V1.UseCase.Interfaces
+{
+    public interface IPostEndpointUseCase
+    {
+         ApiEndpointOptionResponse Execute(CreateEndpointRequest request);
+    }
+}

--- a/TokenAdministrationApi/V1/UseCase/PostApiUseCase.cs
+++ b/TokenAdministrationApi/V1/UseCase/PostApiUseCase.cs
@@ -1,9 +1,5 @@
-using System;
 using TokenAdministrationApi.V1.Boundary.Requests;
 using TokenAdministrationApi.V1.Boundary.Response;
-using TokenAdministrationApi.V1.Domain;
-using TokenAdministrationApi.V1.Domain.Exceptions;
-using TokenAdministrationApi.V1.Factories;
 using TokenAdministrationApi.V1.Gateways;
 using TokenAdministrationApi.V1.UseCase.Interfaces;
 

--- a/TokenAdministrationApi/V1/UseCase/PostApiUseCase.cs
+++ b/TokenAdministrationApi/V1/UseCase/PostApiUseCase.cs
@@ -21,6 +21,5 @@ namespace TokenAdministrationApi.V1.UseCase
         {
             return _gateway.CreateApiLookup(request);
         }
-        
     }
 }

--- a/TokenAdministrationApi/V1/UseCase/PostApiUseCase.cs
+++ b/TokenAdministrationApi/V1/UseCase/PostApiUseCase.cs
@@ -1,0 +1,26 @@
+using System;
+using TokenAdministrationApi.V1.Boundary.Requests;
+using TokenAdministrationApi.V1.Boundary.Response;
+using TokenAdministrationApi.V1.Domain;
+using TokenAdministrationApi.V1.Domain.Exceptions;
+using TokenAdministrationApi.V1.Factories;
+using TokenAdministrationApi.V1.Gateways;
+using TokenAdministrationApi.V1.UseCase.Interfaces;
+
+namespace TokenAdministrationApi.V1.UseCase
+{
+    public class PostApiUseCase : IPostApiUseCase
+    {
+        private readonly ITokensGateway _gateway;
+
+        public PostApiUseCase(ITokensGateway gateway)
+        {
+            _gateway = gateway;
+        }
+        public ApiLookupOptionResponse Execute(CreateApiLookupRequest request)
+        {
+            return _gateway.CreateApiLookup(request);
+        }
+        
+    }
+}

--- a/TokenAdministrationApi/V1/UseCase/PostEndpointUseCase.cs
+++ b/TokenAdministrationApi/V1/UseCase/PostEndpointUseCase.cs
@@ -1,0 +1,26 @@
+using System;
+using TokenAdministrationApi.V1.Boundary.Requests;
+using TokenAdministrationApi.V1.Boundary.Response;
+using TokenAdministrationApi.V1.Domain;
+using TokenAdministrationApi.V1.Domain.Exceptions;
+using TokenAdministrationApi.V1.Factories;
+using TokenAdministrationApi.V1.Gateways;
+using TokenAdministrationApi.V1.UseCase.Interfaces;
+
+namespace TokenAdministrationApi.V1.UseCase
+{
+    public class PostEndpointUseCase : IPostEndpointUseCase
+    {
+        private readonly ITokensGateway _gateway;
+
+        public PostEndpointUseCase(ITokensGateway gateway)
+        {
+            _gateway = gateway;
+        }
+        public ApiEndpointOptionResponse Execute(CreateEndpointRequest request)
+        {
+            return _gateway.CreateEndpointLookup(request);
+        }
+        
+    }
+}

--- a/TokenAdministrationApi/V1/UseCase/PostEndpointUseCase.cs
+++ b/TokenAdministrationApi/V1/UseCase/PostEndpointUseCase.cs
@@ -17,10 +17,10 @@ namespace TokenAdministrationApi.V1.UseCase
         {
             _gateway = gateway;
         }
-        public ApiEndpointOptionResponse Execute(CreateEndpointRequest request)
+
+        public CreateEndpointResponse Execute(int apiLookupId, CreateEndpointRequest request)
         {
-            return _gateway.CreateEndpointLookup(request);
+            return _gateway.CreateEndpoint(apiLookupId, request);
         }
-        
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 services:
   token-administration-api:
     image: token-administration-api
@@ -41,3 +39,29 @@ services:
       - 5432:5432
     env_file:
       - database.env
+
+  token-administration-api-dev:
+    image: token-administration-api-dev
+    build:
+      context: TokenAdministrationApi/
+      dockerfile: ./Dockerfile
+    ports:
+      - 5001:3000
+    environment:
+      - CONNECTION_STRING=Host=host.docker.internal;Port=${LOCAL_DEV_DB_PORT:-5434};Database=devdb;Username=postgres;Password=mypassword
+      - jwtSecret=this_is_a_very_long_secret_key_123456
+    links:
+      - local-dev-database
+
+  local-dev-database:
+    image: postgres:16
+    container_name: dev-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: devdb
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: mypassword
+    ports:
+      - "${LOCAL_DEV_DB_PORT:-5434}:5432"
+    volumes:
+      - ./postgres_data:/docker-entrypoint-initdb.d


### PR DESCRIPTION
Adds support for creating API lookup records and endpoint lookup records through the token administration API.

## Changes included

- Added `POST /api/v1/apis` to create API lookup entries with API name and gateway ID.
- Added `POST /api/v1/apis/{apiLookupId}/endpoints` to create endpoint entries for an existing API.
- Added request/response models for API and endpoint creation.
- Added use cases and gateway methods for creating API and endpoint configuration.
- Added duplicate checks for API name, API gateway ID, and endpoint names per API.
- Added error handling for duplicate API/endpoint records and missing API lookups.
- Registered the new use cases in dependency injection.
- Added controller, gateway, and E2E coverage for the new configuration endpoints.
- Fixed formatting issues reported by `dotnet format`.

## Testing

- Added tests for successful API and endpoint creation.
- Added tests for duplicate API and endpoint validation.
- Added tests for missing API lookup handling.
- Formatting fixes have been pushed after CI reported whitespace errors.